### PR TITLE
release: v1.4.2 — 添加 Fork 上游自动同步

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -1,0 +1,35 @@
+name: Sync upstream
+
+on:
+  schedule:
+    # Runs daily at 04:20 Asia/Shanghai (20:20 UTC).
+    - cron: '20 20 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: sync-upstream-main
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    # Run only in forks. Scheduled sync is opt-in;
+    # manual dispatch remains available without setting the repository variable.
+    if: >-
+      github.event.repository.fork == true &&
+      (github.event_name == 'workflow_dispatch' || vars.AUTO_SYNC_UPSTREAM == 'true')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Sync main branch from upstream
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          gh api \
+            --method POST \
+            "repos/${REPOSITORY}/merge-upstream" \
+            -f branch=main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.2] - 2026-08-01
+
+### Added
+- 新增默认关闭的 Fork 上游自动同步工作流，用户可通过仓库变量选择开启每日定时同步，也可随时手动执行。
+- 同步过程使用 GitHub Fork 同步接口更新 `main` 分支，无需 PAT；发生合并冲突时保留用户现有代码并停止任务，避免强制覆盖。
+
+### Changed
+- 完善中英文部署文档，补充自动同步的开启步骤、Cloudflare Git 集成自动部署条件、手动同步方式及冲突处理建议。
+
 ## [1.4.1] - 2026-08-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@
 - [架构说明](#architecture)
 - [快速部署](#quick-start)
   - [GitHub 绑定自动部署](#方式一通过-github-绑定自动部署推荐)
+    - [自动同步上游版本](#可选自动同步上游版本)
   - [本地命令行部署](#方式二本地命令行部署)
   - [配置 Turnstile](#可选配置-turnstile-人机验证)
   - [配置 GitHub OAuth](#可选配置-github-oauth-登录与服务器管理)
@@ -214,6 +215,19 @@ flowchart TB
 5. **绑定自定义域名**（可选）：进入 Worker 的 Settings → Domains & Routes → Add，输入你的域名并确认。
 
 > **说明**：如需部署 test 环境，可 Fork 后在 `test` 分支上重复上述步骤，创建独立的 Worker（如 `cloudssh-test`）。两个环境的 Durable Objects 数据完全隔离，各自独立。
+
+##### 可选：自动同步上游版本
+
+Fork 仓库可以通过内置的 `Sync upstream` GitHub Actions 工作流，定时将本项目 `main` 分支的最新版本同步到自己的 `main` 分支。该功能**默认关闭**，开启后每天北京时间 04:20 检查一次；同步产生的分支更新会由 Cloudflare Git 集成自动构建并部署，无需额外配置部署开关。
+
+1. 确认 Cloudflare Worker 连接的是你自己的 Fork 仓库，且 Production branch 设置为 `main`，自动构建处于开启状态。
+2. 进入 Fork 仓库的 **Actions** 页面并启用工作流。已有 Fork 如果尚未包含 `Sync upstream`，请先通过 GitHub 的 **Sync fork** 功能手动同步一次。
+3. 进入 **Settings → Secrets and variables → Actions → Variables**，创建 Repository variable：
+   - Name：`AUTO_SYNC_UPSTREAM`
+   - Value：`true`
+4. 如需立即同步，进入 **Actions → Sync upstream → Run workflow** 手动执行；手动执行不要求设置上述变量。
+
+> **同步说明**：工作流使用 GitHub 提供的 Fork 同步接口，不需要 PAT，也不会强制覆盖分支。若你的 `main` 与上游存在无法自动合并的冲突，任务会失败并保留现有代码，需要手动解决冲突。建议不要直接修改部署用的 `main` 分支，并将域名、密钥及环境变量保存在 Cloudflare Dashboard 中。
 
 #### 方式二：本地命令行部署
 

--- a/README_en.md
+++ b/README_en.md
@@ -47,6 +47,7 @@
 - [Architecture](#architecture)
 - [Quick Deployment](#quick-start)
   - [GitHub Integration](#method-1-deploy-via-github-integration-recommended)
+    - [Automatically Sync Upstream](#optional-automatically-sync-upstream-releases)
   - [Local CLI Deployment](#method-2-local-cli-deployment)
   - [Configure Turnstile](#optional-configure-turnstile-human-verification)
   - [Configure GitHub OAuth](#optional-configure-github-oauth-login--server-management)
@@ -214,6 +215,19 @@ This project implements a complete SSH-2.0 protocol stack:
 5. **Bind Custom Domain** (Optional): Go to Worker Settings → Domains & Routes → Add, enter your domain and confirm.
 
 > **Note**: To deploy a test environment, repeat the above steps on the `test` branch to create a separate Worker (e.g., `cloudssh-test`). The Durable Objects data between both environments is completely isolated.
+
+##### Optional: Automatically Sync Upstream Releases
+
+A fork can use the built-in `Sync upstream` GitHub Actions workflow to periodically synchronize the latest `main` branch from this project into its own `main` branch. This feature is **disabled by default**. Once enabled, it checks daily at 04:20 Asia/Shanghai; branch updates created by a successful sync are automatically built and deployed by Cloudflare Git integration, so no additional deployment toggle is required.
+
+1. Make sure the Cloudflare Worker is connected to your fork, its Production branch is set to `main`, and automatic builds are enabled.
+2. Open the fork's **Actions** page and enable workflows. If an existing fork does not yet contain `Sync upstream`, first use GitHub's **Sync fork** feature once to obtain the workflow.
+3. Go to **Settings → Secrets and variables → Actions → Variables** and create a Repository variable:
+   - Name: `AUTO_SYNC_UPSTREAM`
+   - Value: `true`
+4. To sync immediately, open **Actions → Sync upstream → Run workflow**. Manual runs do not require the variable above.
+
+> **Sync behavior**: The workflow uses GitHub's fork synchronization API, requires no PAT, and never force-overwrites the branch. If your `main` branch cannot be merged with upstream automatically, the job fails while preserving the existing code and the conflict must be resolved manually. Avoid editing the deployment `main` branch directly, and keep domains, secrets, and environment variables in the Cloudflare Dashboard.
 
 #### Method 2: Local CLI Deployment
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudssh",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "packageManager": "pnpm@11.8.0",
   "description": "纯 Cloudflare 架构 Web SSH 工具",
   "main": "src/worker/index.ts",


### PR DESCRIPTION
## 发布内容

- 新增默认关闭的 Fork 上游自动同步 GitHub Actions 工作流
- 支持通过 `AUTO_SYNC_UPSTREAM=true` 开启每日定时同步，也可手动触发
- 使用 GitHub Fork 同步接口更新 `main`，无需 PAT，冲突时不强制覆盖
- 同步成功后由 Cloudflare Git 集成自动构建部署，无需额外部署开关
- 更新中英文 README，补充开启步骤、部署条件及冲突处理说明
- 将项目版本升级至 `1.4.2` 并更新 CHANGELOG

## 验证

- Worker 与前端 TypeScript 类型检查通过
- 30 个测试文件、463 项单元与集成测试通过
- 前端生产构建及内联产物生成成功
- 19 项 Chromium E2E 与无障碍测试通过