### PR TITLE
fix(ssh): recompute encryption state per packet in processPackets()

### DIFF
--- a/src/worker/ssh-session.ts
+++ b/src/worker/ssh-session.ts
@@ -495,14 +495,20 @@ export class SSHSession {
   }
 
   private async processPackets(): Promise<void> {
-    const cipher = this.decryptCipher ? getCipherSpec(this.negotiatedCipherS2C) : null;
-    const blockSize = cipher ? cipher.blockSize : 8;
-    const hasAuthTag = !!cipher?.aead;
-    const macLength = this.decryptCipher && !hasAuthTag ? getMacSpec(this.negotiatedMacS2C).length : 0;
-    const hasDecrypt = !!this.decryptCipher;
-    this.sendDebug(() => `processPackets: blockSize=${blockSize}, hasDecrypt=${hasDecrypt}, bufferLen=${this.packetParser.getBufferLength()}`);
-
     while (true) {
+      // Encryption state changes after handling SSH_MSG_NEWKEYS
+      // (handlePacket -> enableEncryption). The first encrypted packet can
+      // arrive in the same read chunk as NEWKEYS, so these parameters MUST be
+      // recomputed for every packet. If they go stale, the ciphertext's first
+      // bytes are misread as packet_length, e.g. "Packet length 965473881
+      // exceeds maximum allowed size 262144".
+      const cipher = this.decryptCipher ? getCipherSpec(this.negotiatedCipherS2C) : null;
+      const blockSize = cipher ? cipher.blockSize : 8;
+      const hasAuthTag = !!cipher?.aead;
+      const macLength = this.decryptCipher && !hasAuthTag ? getMacSpec(this.negotiatedMacS2C).length : 0;
+      const hasDecrypt = !!this.decryptCipher;
+      this.sendDebug(() => `processPackets: blockSize=${blockSize}, hasDecrypt=${hasDecrypt}, bufferLen=${this.packetParser.getBufferLength()}`);
+
       try {
         const packet = await this.packetParser.nextPacket(
           blockSize,


### PR DESCRIPTION
## 问题

修复 `processPackets()` 的一个加密状态切换 bug，会导致连接报错：

```
Packet length 965473881 exceeds maximum allowed size 262144
```

## 根因

`processPackets()` 在进入 `while` 循环前只计算一次解密状态（`cipher` / `blockSize` / `hasAuthTag` / `macLength`）。收到 `SSH_MSG_NEWKEYS` 后，`handlePacket()` 会调用 `enableEncryption()` 设置 `this.decryptCipher`，但循环仍使用加密前的旧参数（`blockSize=8`、`hasAuthTag=false`），于是把第一个加密包的前 4 字节误读成 `packet_length`。

当 SSH 服务器把 `SSH_MSG_NEWKEYS` 和之后的第一个加密包放在同一个 TCP read chunk 里返回时几乎必现；若恰好分成两次 TCP read，则会重新进入 `processPackets()` 并重新计算状态，反而正常 —— 所以表现为「有的服务器能连、有的不能连，甚至时好时坏」。

AES-GCM（本项目的优先加密算法）下这个问题尤其明显：packet_length 本身不加密、作为 AAD 认证，切换前后的解析状态必须准确。

## 修复

把加密状态的计算移进 `while` 循环内，每包重算。**未修改** `MAX_PACKET_SIZE`（保持 256KB，符合 RFC 4253 §6.1）。

## 验证

- `pnpm run typecheck` 通过
- `pnpm test`（tests/ssh + tests/worker，466 个用例）全部通过
