### PR TITLE
release: 发布 v1.9.1 SSH 密钥切换兼容修复版本

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.1] - 2026-08-18
+
+### Fixed
+
+- 修复服务端将 `SSH_MSG_NEWKEYS` 与首个加密包放在同一 TCP 数据块返回时，SSH 会话沿用旧分包参数并报出超大 `packet_length` 的问题。
+- 密钥切换后逐包重新读取 AES-GCM 或 AES-CTR/HMAC 的块大小、认证标签和 MAC 长度，避免错误解析已加密数据。
+
+### Changed
+
+- 新增覆盖 AES-GCM、AES-CTR/HMAC 状态切换及真实同批加密数据的回归测试。
+- 更新中英文兼容性说明，并补充本次修复的贡献者信息。
+
 ## [1.9.0] - 2026-08-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@
 
 - **纯 TypeScript SSH-2.0 实现**：完全自研的 SSH 协议栈，不依赖任何第三方 SSH 库，基于 Web Crypto API 实现全部加密操作。
 - **多算法密钥交换**：支持 Curve25519-SHA256（优先）和 ECDH-NISTP256 两种 KEX 算法，适配各类 SSH 服务器（包括 Dropbear）。
+- **可靠的密钥切换与分包处理**：逐包读取当前加密与认证状态，兼容服务端将 `SSH_MSG_NEWKEYS` 和首个加密包合并在同一 TCP 数据块中返回的情况。
 - **IPv4/IPv6 双栈**：完整支持 IPv4 和 IPv6 地址连接，包括 IPv6 方括号格式自动处理。
 - **多种认证方式**：支持标准 SSH 密码认证、RFC 4256 `keyboard-interactive` 多轮交互认证，以及 OpenSSH 格式的 Ed25519、ECDSA P-256/P-384/P-521 和 RSA 私钥认证。交互认证支持密码、OTP、多字段提示与公钥后的二次验证；服务器提示会在绑定当前连接的安全对话框中展示，已保存密码仅在用户明确选择后代填。RSA 默认使用 RSA-SHA2-256/512，只有显式兼容配置才允许旧 `ssh-rsa` SHA-1。
 - **SSH 跳板机/堡垒机**：登录用户可以为已保存服务器选择另一台已保存服务器作为跳板。CloudSSH 使用标准 RFC 4254 `direct-tcpip` 通道逐层建立 SSH，不依赖远端安装 `ssh`、`nc` 或 `socat`；支持最多 3 级跳转，最终目标的终端、SFTP 与 AI Agent 均复用完整加密链路。每一跳独立认证和验证路径隔离的主机指纹。
@@ -498,6 +499,7 @@ test 分支（开发/测试）  ──合并──>  main 分支（生产）
 | [TanXin (@newbietan)](https://github.com/newbietan) | 项目发起与持续维护；Cloudflare Serverless、SSH/SFTP、AI Agent、安全体系、主题系统及工程化建设                            |
 | [David xu (@xqdoo00o)](https://github.com/xqdoo00o) | Dropbear 兼容、trzsz 文件传输迁移、PTY 尺寸处理，以及会话退出与重连交互优化                                              |
 | [vonl1 (@vonl1)](https://github.com/vonl1)          | 终端选区自动复制、兼容 Vim 的右键粘贴体验、服务器 IPv4/IPv6 掩码与完整地址快捷复制，以及服务器操作系统自动识别与品牌图标 |
+| [Leon Xu (@xuthuslei)](https://github.com/xuthuslei)    | 修复 `SSH_MSG_NEWKEYS` 与首个加密包同批到达时的加密状态切换和数据包解析兼容问题                                       |
 
 名单及贡献说明依据 Git 提交历史与已接收的 Pull Request 整理；同一贡献者在历史中可能使用过不同的 Git 作者名称或邮箱。完整记录请参阅 [GitHub Contributors](https://github.com/newbietan/CloudSSH/graphs/contributors)。欢迎通过 Issue 和 Pull Request 参与项目建设。
 

--- a/README_en.md
+++ b/README_en.md
@@ -84,6 +84,7 @@
 
 - **Pure TypeScript SSH-2.0 Implementation**: Fully self-developed SSH protocol stack, with no dependency on any third-party SSH libraries, implementing all cryptographic operations based on Web Crypto API.
 - **Multi-Algorithm Key Exchange**: Supports Curve25519-SHA256 (preferred) and ECDH-NISTP256 KEX algorithms, compatible with various SSH servers (including Dropbear).
+- **Reliable Key Transitions and Packet Framing**: Re-evaluates encryption and authentication state for every packet, including servers that return `SSH_MSG_NEWKEYS` and the first encrypted packet in the same TCP chunk.
 - **IPv4/IPv6 Dual Stack**: Full support for both IPv4 and IPv6 address connections, including automatic handling of IPv6 bracket notation.
 - **Multiple Auth Methods**: Supports standard SSH password authentication, multi-round RFC 4256 `keyboard-interactive` authentication, and OpenSSH-format Ed25519, ECDSA P-256/P-384/P-521, and RSA private keys. Interactive authentication supports passwords, OTPs, multiple prompts, and a second factor after public-key authentication. Server prompts appear in a connection-bound safety dialog, and a saved password is substituted only after an explicit user action. RSA uses RSA-SHA2-256/512 by default; legacy `ssh-rsa` SHA-1 is allowed only through explicit compatibility configuration.
 - **SSH Jump Hosts / Bastions**: Signed-in users may select another saved server as a jump host. CloudSSH builds each layer with the standard RFC 4254 `direct-tcpip` channel and does not require `ssh`, `nc`, or `socat` on the remote host. Up to 3 jump hosts are supported; the final target's terminal, SFTP, and AI Agent use the complete encrypted chain. Authentication and path-scoped host-key verification run independently at every hop.
@@ -479,6 +480,7 @@ Thank you to the following contributors for improving CloudSSH's code, compatibi
 | [TanXin (@newbietan)](https://github.com/newbietan) | Project creator and maintainer; Cloudflare Serverless architecture, SSH/SFTP, AI Agent, security, theming, and engineering infrastructure |
 | [David xu (@xqdoo00o)](https://github.com/xqdoo00o) | Dropbear compatibility, migration to trzsz file transfer, PTY sizing, and session exit/reconnection improvements |
 | [vonl1 (@vonl1)](https://github.com/vonl1) | Terminal selection auto-copy, Vim-compatible right-click paste, masked IPv4/IPv6 display with quick full-address copy, and automatic server OS detection with branded icons |
+| [Leon Xu (@xuthuslei)](https://github.com/xuthuslei) | Fixed encryption-state transitions and packet parsing when `SSH_MSG_NEWKEYS` and the first encrypted packet arrive in the same TCP chunk |
 
 The list and contribution summaries are based on Git history and accepted Pull Requests; one contributor may appear under multiple historical Git author names or email addresses. See [GitHub Contributors](https://github.com/newbietan/CloudSSH/graphs/contributors) for the complete record. Issues and Pull Requests are welcome.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudssh",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "packageManager": "pnpm@11.8.0",
   "description": "纯 Cloudflare 架构 Web SSH 工具",
   "main": "src/worker/index.ts",

--- a/src/worker/ssh-session.ts
+++ b/src/worker/ssh-session.ts
@@ -495,14 +495,20 @@ export class SSHSession {
   }
 
   private async processPackets(): Promise<void> {
-    const cipher = this.decryptCipher ? getCipherSpec(this.negotiatedCipherS2C) : null;
-    const blockSize = cipher ? cipher.blockSize : 8;
-    const hasAuthTag = !!cipher?.aead;
-    const macLength = this.decryptCipher && !hasAuthTag ? getMacSpec(this.negotiatedMacS2C).length : 0;
-    const hasDecrypt = !!this.decryptCipher;
-    this.sendDebug(() => `processPackets: blockSize=${blockSize}, hasDecrypt=${hasDecrypt}, bufferLen=${this.packetParser.getBufferLength()}`);
-
     while (true) {
+      // Encryption state changes after handling SSH_MSG_NEWKEYS
+      // (handlePacket -> enableEncryption). The first encrypted packet can
+      // arrive in the same read chunk as NEWKEYS, so these parameters MUST be
+      // recomputed for every packet. If they go stale, the ciphertext's first
+      // bytes are misread as packet_length, e.g. "Packet length 965473881
+      // exceeds maximum allowed size 262144".
+      const cipher = this.decryptCipher ? getCipherSpec(this.negotiatedCipherS2C) : null;
+      const blockSize = cipher ? cipher.blockSize : 8;
+      const hasAuthTag = !!cipher?.aead;
+      const macLength = this.decryptCipher && !hasAuthTag ? getMacSpec(this.negotiatedMacS2C).length : 0;
+      const hasDecrypt = !!this.decryptCipher;
+      this.sendDebug(() => `processPackets: blockSize=${blockSize}, hasDecrypt=${hasDecrypt}, bufferLen=${this.packetParser.getBufferLength()}`);
+
       try {
         const packet = await this.packetParser.nextPacket(
           blockSize,

--- a/tests/e2e/mobile-user-space.spec.ts
+++ b/tests/e2e/mobile-user-space.spec.ts
@@ -1,3 +1,4 @@
+/// <reference lib="es2022" />
 import { expect, test } from '@playwright/test';
 import { blockOptionalThirdPartyAssets } from './helpers';
 
@@ -113,6 +114,10 @@ test.describe('响应式断点边界', () => {
 
 test('移动端服务器卡片不会被长文本撑宽且表单弹窗在视口内滚动', async ({ page }) => {
   await page.goto('/?lang=zh-CN');
+  await expect(page.locator('.server-card')).toHaveCount(3);
+  await expect.poll(() => page.locator('#card-1 .server-card-title').evaluate((title) =>
+    getComputedStyle(title).overflow,
+  )).toBe('hidden');
 
   const cardLayout = await page.locator('#card-1').evaluate((card) => {
     const title = card.querySelector<HTMLElement>('.server-card-title')!;

--- a/tests/worker/ssh-session-packet-state.test.ts
+++ b/tests/worker/ssh-session-packet-state.test.ts
@@ -1,0 +1,141 @@
+/// <reference lib="es2022" />
+import { describe, expect, it, vi } from 'vitest';
+import { SSHAESCTRCipher, SSHHMAC } from '../../src/ssh/crypto';
+import { SSHPacketBuilder } from '../../src/ssh/packet';
+import { concat } from '../../src/ssh/utils';
+import { SSHSession } from '../../src/worker/ssh-session';
+
+function createSession() {
+  const ws = {
+    readyState: 1,
+    send: vi.fn(),
+    close: vi.fn(),
+  };
+  const socket = { close: vi.fn() };
+  const session = new SSHSession(
+    ws as unknown as WebSocket,
+    socket as never,
+    {
+      host: 'ssh.example.com',
+      port: 22,
+      username: 'alice',
+      password: 'secret',
+      authMethod: 'password',
+    },
+  );
+  return { session, ws, socket };
+}
+
+describe('SSHSession packet encryption state', () => {
+  it.each([
+    {
+      cipher: 'aes128-gcm@openssh.com',
+      mac: 'none',
+      expectedAuthTag: true,
+      expectedMacLength: 0,
+    },
+    {
+      cipher: 'aes128-ctr',
+      mac: 'hmac-sha2-256',
+      expectedAuthTag: false,
+      expectedMacLength: 32,
+    },
+  ])(
+    'recomputes $cipher framing after a packet enables encryption',
+    async ({ cipher, mac, expectedAuthTag, expectedMacLength }) => {
+      const { session } = createSession();
+      const internal = session as any;
+      const decrypt = vi.fn(async (data: Uint8Array) => data);
+      const verify = vi.fn(async () => true);
+      const nextPacket = vi.fn()
+        .mockResolvedValueOnce({
+          length: 12,
+          paddingLength: 10,
+          payload: new Uint8Array([21]),
+          mac: new Uint8Array(0),
+        })
+        .mockResolvedValueOnce(null);
+
+      internal.negotiatedCipherS2C = cipher;
+      internal.negotiatedMacS2C = mac;
+      internal.packetParser = {
+        nextPacket,
+        getBufferLength: vi.fn(() => 0),
+      };
+      internal.handlePacket = vi.fn(async () => {
+        internal.decryptCipher = { decrypt };
+        internal.decryptMac = expectedMacLength > 0 ? { verify } : null;
+      });
+
+      await internal.processPackets();
+
+      expect(nextPacket).toHaveBeenCalledTimes(2);
+      expect(nextPacket.mock.calls[0][0]).toBe(8);
+      expect(nextPacket.mock.calls[0][2]).toBe(false);
+      expect(nextPacket.mock.calls[0][3]).toBe(0);
+
+      const [blockSize, decryptPacket, hasAuthTag, macLength, verifyMac] = nextPacket.mock.calls[1];
+      expect(blockSize).toBe(16);
+      expect(hasAuthTag).toBe(expectedAuthTag);
+      expect(macLength).toBe(expectedMacLength);
+      expect(typeof decryptPacket).toBe('function');
+      expect(typeof verifyMac === 'function').toBe(expectedMacLength > 0);
+    },
+  );
+
+  it('parses NEWKEYS and the first CTR/HMAC packet from one TCP chunk', async () => {
+    const { session, ws, socket } = createSession();
+    const internal = session as any;
+    const keys = {
+      ivClientToServer: new Uint8Array(16).fill(0x11),
+      ivServerToClient: new Uint8Array(16).fill(0x22),
+      encKeyClientToServer: new Uint8Array(16).fill(0x33),
+      encKeyServerToClient: new Uint8Array(16).fill(0x44),
+      integrityKeyC2S: new Uint8Array(32).fill(0x55),
+      integrityKeyS2C: new Uint8Array(32).fill(0x66),
+      sessionID: new Uint8Array(32).fill(0x77),
+    };
+
+    internal.state = 'kex';
+    internal.derivedKeys = keys;
+    internal.negotiatedCipherC2S = 'aes128-ctr';
+    internal.negotiatedCipherS2C = 'aes128-ctr';
+    internal.negotiatedMacC2S = 'hmac-sha2-256';
+    internal.negotiatedMacS2C = 'hmac-sha2-256';
+    internal.writeSocket = vi.fn(async () => {});
+    const handlePacket = vi.spyOn(internal, 'handlePacket');
+
+    const serverCipher = new SSHAESCTRCipher(
+      keys.encKeyServerToClient,
+      keys.ivServerToClient,
+    );
+    const serverMac = new SSHHMAC('hmac-sha2-256', keys.integrityKeyS2C);
+    await serverCipher.init();
+    await serverMac.init();
+
+    const newKeysPacket = await SSHPacketBuilder.build(
+      new Uint8Array([21]),
+      8,
+      null,
+      0,
+    );
+    const extInfoPacket = await SSHPacketBuilder.build(
+      new Uint8Array([7, 0, 0, 0, 0]),
+      16,
+      (data, seq, aad) => serverCipher.encrypt(data, seq, aad),
+      1,
+      false,
+      (packet, seq) => serverMac.sign(packet, seq),
+    );
+
+    internal.packetParser.feed(concat(newKeysPacket, extInfoPacket));
+    await internal.processPackets();
+
+    expect(handlePacket).toHaveBeenCalledTimes(2);
+    expect(handlePacket.mock.calls.map(([packet]: any[]) => packet.payload[0])).toEqual([21, 7]);
+    expect(internal.packetParser.getBufferLength()).toBe(0);
+    expect(internal.state).toBe('auth');
+    expect(ws.close).not.toHaveBeenCalled();
+    expect(socket.close).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 发布说明

本次发布将 CloudSSH 升级至 `v1.9.1`，修复 SSH 密钥切换后同一 TCP 数据块内首个加密包可能被旧分包参数解析的问题。

## 主要变更

- `processPackets()` 在每个数据包解析前重新读取当前加密算法、块大小、AEAD 标签和 MAC 长度。
- 修复服务端将 `SSH_MSG_NEWKEYS` 与首个加密包合并返回时可能出现的超大 `packet_length` 错误。
- 新增 AES-GCM、AES-CTR/HMAC 状态切换及真实 CTR/HMAC 同批数据回归测试。
- 更新中英文兼容性说明，并补充贡献者 Leon Xu（@xuthuslei）。
- 稳定移动端服务器卡片布局 E2E，在读取布局前等待最终渲染样式生效。

## 验证

- `pnpm run verify`：通过
- Worker 与前端类型检查：通过
- 单元及集成测试：44 个测试文件、587 项测试通过
- Chromium/WebKit E2E 与无障碍测试：50 项通过，1 项按条件跳过
- 前端生产构建：通过
- `git diff --check`：通过
- `test` 环境 CI 与部署：通过（https://github.com/newbietan/CloudSSH/actions/runs/32107868226）

Closes #87

包含 #88 的原作者提交。