### PR TITLE
release: 发布 v1.10.2 版本

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,14 +4,15 @@ on:
   push:
     branches: [test, main]
     paths-ignore:
-      - '*.md'
+      - '**/*.md'
       - 'LICENSE'
       - '.gitignore'
       - 'docs/**'
-      - '*.png'
-      - '*.jpg'
-      - '*.gif'
-      - '*.svg'
+      - '**/*.png'
+      - '**/*.jpg'
+      - '**/*.jpeg'
+      - '**/*.gif'
+      - '**/*.svg'
       - 'AGENTS.md'
 
 jobs:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@
   - scripts/build-html.js (构建流程)
   - package.json (依赖、脚本命令)
   - src/types.ts (Env 接口、类型定义)
+  - biome.json (代码格式与 lint 约定)
 -->
 
 ## Project Overview
@@ -35,6 +36,8 @@ src/
 │   ├── server-tags.ts # 服务器标签规范化与 SQLite JSON 序列化
 │   ├── os-detect.ts  # 远端操作系统输出解析、规范 key 与持久化白名单
 │   ├── auth.ts       # GitHub OAuth handling
+│   ├── dns-check.ts  # DNS-over-HTTPS 解析 + 统一 IP 块检查（DNS rebinding 防重绑定 SSRF 防护）
+│   ├── ip-geo.ts     # 保存直连服务器时 IPinfo 区域推断，映射为 DO locationHint
 │   ├── agent/        # AI Agent system
 │   │   ├── core.ts       # Agent control loop (LLM calls, tool execution)
 │   │   ├── tools.ts      # 8 tool definitions (execute_command, detect_environment, list_processes, service_manage, docker_manage, etc.)
@@ -66,28 +69,54 @@ src/
 
 frontend/
 ├── src/
-│   ├── main.ts       # Frontend entry point (routing, theme, event handlers)
-│   ├── terminal.ts   # xterm.js terminal setup (search, dynamic RTT latency, log export)
+│   ├── main.ts            # Frontend entry point (路由、theme、i18n、事件处理、Esc 快速返回终端)
+│   ├── terminal.ts        # xterm.js terminal setup (search, dynamic RTT latency, log export, 选区->Agent)
+│   ├── terminal-layout.ts # 响应式终端字体与视口尺寸（桌面/平板/移动）
+│   ├── terminal-status.ts # SSH 状态事件 → i18n 文案翻译与状态栏渲染
+│   ├── terminal-text.ts   # 终端等宽文本宽度计算（CJK 全角/Emoji 占 2 列）
+│   ├── network-quality.ts # 双段延迟阈值与网络质量分级（good/fair/poor）
+│   ├── clipboard.ts       # Clipboard API 写入与旧版 execCommand 回退
+│   ├── ui-feedback.ts     # 轻量通知/toast 反馈组件
+│   ├── host-display.ts    # IPv4/IPv6 字面量校验与隐私掩码文本
+│   ├── os-icons.ts        # 操作系统品牌图标（内嵌 simple-icons SVG）
+│   ├── port.ts            # 端口解析与 1-65535 校验
+│   ├── regions.ts         # DO locationHint 区域选项共享数据（Auto + 白名单）
+│   ├── theme.ts           # Theme V2 内置主题、UI CSS 变量与外观预设
 │   ├── auth-challenge-dialog.ts # RFC 4256 multi-round authentication prompt UI
 │   ├── mobile-terminal.ts # Mobile viewport, shortcut toolbar, clipboard and landscape controller
-│   ├── mobile-input.ts # Pure iOS IME diff and one-shot modifier helpers
-│   ├── known-hosts.ts # 已验证主机指纹消息校验、本地/云端 TOFU 持久化
-│   ├── tab-manager.ts # Tab manager (multi-session terminal/SFTP/Agent coordinator)
-│   ├── sftp-panel.ts # SFTP file manager UI (multi-select, batch actions, queue, cancel)
-│   ├── sftp-selection.ts # Pure multi-selection state model
-│   ├── auth-form.ts  # Auth form & encrypted anonymous credentials storage/autofill
-│   ├── server-list.ts # Server UI (tags, search, 9-card pagination, CRUD/connect)
-│   ├── share-manager.ts # Owner UI for creating, revoking, and auditing one-time shares
-│   ├── share-session.ts # Public one-time share landing and claim flow
+│   ├── mobile-input.ts    # Pure iOS IME diff and one-shot modifier helpers
+│   ├── known-hosts.ts     # 已验证主机指纹消息校验、本地/云端 TOFU 持久化
+│   ├── tab-manager.ts     # Tab manager (multi-session terminal/SFTP/Agent coordinator, 返回终端按钮联动)
+│   ├── sftp-panel.ts      # SFTP file manager UI (multi-select, batch actions, queue, cancel)
+│   ├── sftp-selection.ts  # Pure multi-selection state model
+│   ├── auth-form.ts       # Auth form & encrypted anonymous credentials storage/autofill
+│   ├── server-list.ts     # Server UI (tags, search, responsive 9/6/3-card pagination, CRUD/connect)
+│   ├── share-manager.ts   # Owner UI for creating, revoking, and auditing one-time shares
+│   ├── share-session.ts   # Public one-time share landing and claim flow
 │   ├── agent/
-│   │   ├── agent-panel.ts  # AI assistant sidebar (context attachments, streaming, Markdown, confirmations)
+│   │   ├── agent-panel.ts # AI assistant sidebar (context attachments, streaming, Markdown, confirmations)
+│   │   ├── code-actions.ts # Agent 代码块语言归一化与 Shell 单行命令可填性判定
 │   │   └── terminal-selection-context.ts # Selection snapshots and untrusted-data prompt boundary
 │   ├── snippet-manager.ts # 命令片段库面板（云端/本地双后端、填入/填入并执行、编辑/删除）
 │   ├── snippet-store.ts   # 片段存储层（RemoteSnippetStore + LocalSnippetStore + 错误映射）
-│   ├── ai-config.ts  # AI model configuration modal
-│   ├── style.css     # Global styles (CSS variable theme system)
-│   └── turnstile.d.ts # Turnstile type declarations
-└── vite.config.ts    # Dev proxy to localhost:8787
+│   ├── ai-config.ts       # AI model configuration modal
+│   ├── i18n/
+│   │   ├── index.ts        # 语言解析、词条查询（t）与 locale 变更通知
+│   │   └── locales/        # zh-CN.ts / en-US.ts 词条字典
+│   ├── style.css           # Global styles (CSS variable theme system)
+│   └── turnstile.d.ts      # Turnstile type declarations
+└── vite.config.ts          # Dev proxy to localhost:8787（+ esbuild minifySyntax 关闭以规避 xterm 6 DECRQM bug）
+```
+
+tests/
+
+```
+├── README.md            # 测试套件说明（目录结构、运行命令）
+├── build/               # 生产构建、可复现性与无原生弹窗回归
+├── e2e/                 # Chromium Playwright 交互与 axe 无障碍检查
+├── ssh/                 # SSH 算法、认证、KEX、加密、通道与测试密钥夹具
+├── worker/              # Worker 路由、安全、DNS 防重绑定、UserDB/标签/片段/跳板/分享策略测试
+└── *.test.ts            # 前端源码级回归（i18n、剪贴板、SFTP 选择、主题、终端状态/文本等）
 ```
 
 ## Development Commands
@@ -111,8 +140,17 @@ pnpm run sync:theme-editor
 # Run tests
 pnpm test
 
+# Generate coverage report (output to coverage/)
+pnpm run test:coverage
+
+# Watch mode for tests
+pnpm run test:watch
+
 # Run worker + frontend type checks
 pnpm run typecheck
+
+# Type-check worker or frontend separately
+pnpm run typecheck:worker / pnpm run typecheck:frontend
 
 # Run browser E2E and accessibility tests
 pnpm run test:e2e
@@ -162,11 +200,15 @@ Required for optional features (configured in `wrangler.toml` or Cloudflare Dash
 - `ENABLE_SSH_SHARING` - Optional; `true` enables one-time audited SSH sharing for signed-in owners (disabled by default)
 - `TURNSTILE_SECRET` / `TURNSTILE_SITEKEY` - Bot verification
 - `BASE_URL` - OAuth callback URL
+- `STRICT_HOST_KEY_VERIFY` - Optional; `false` skips host-key signature verification failures (default true, fails closed)
+- `DEBUG_MODE` - Optional; `true` appends debug info to API responses（wrangler.toml `[vars]` 已声明 `DEBUG_MODE`）
+
+> 注意：`Env` 中声明的 `MAX_CONNECTIONS` / `IDLE_TIMEOUT` 属预留变量，当前代码未读取，切勿依赖。
 
 ## API Routes
 
 | Route | Method | Auth | Description |
-|-------|--------|------|-------------|
+| ------- | -------- | ------ | ------------- |
 | `/api/auth/github` | GET | No | GitHub OAuth redirect |
 | `/api/auth/callback` | GET | No | OAuth callback, creates user + session |
 | `/api/auth/logout` | POST | No | Logout, clears session |
@@ -192,12 +234,19 @@ Required for optional features (configured in `wrangler.toml` or Cloudflare Dash
 
 ## Testing
 
-Tests use Vitest. Run with:
+Tests use Vitest for unit/integration and Playwright + axe for browser E2E:
+
 ```bash
-pnpm test
+pnpm test            # Vitest 单元与集成测试
+pnpm run test:coverage  # 覆盖率（输出到 coverage/）
+pnpm run test:e2e    # Playwright 浏览器 E2E 与 axe 无障碍检查
+pnpm run verify      # typecheck + test + build:frontend + test:e2e 完整门禁
 ```
 
-Test files should be in `tests/` directory with `.test.ts` extension.
+- 测试文件位于 `tests/` 目录，`.test.ts` 后缀（详见 Key Directories 中的 `tests/` 结构）。
+- `tests/ssh/fixtures/` 中的私钥只用于公开协议测试，绝不可用于真实服务器。
+- E2E 首次运行需安装浏览器：`pnpm exec playwright install chromium`。
+- 新增前端文案必须同时提供 zh-CN/en-US 词条，`i18n.test.ts` 会校验两端词条对齐。
 
 ## Git 工作流规范
 
@@ -235,7 +284,7 @@ release: 发布新版本
 ### 分支用途
 
 | 分支 | 用途 | 可直接推送 |
-|------|------|-----------|
+| ------ | ------ | ----------- |
 | `test` | 所有开发、测试、PR 合入 | ✅ |
 | `main` | 生产环境，仅通过 test 合入 | ❌（保护分支） |
 
@@ -252,7 +301,7 @@ release: 发布新版本
 9. **SSH rate limiting** - `/api/ssh` uses a bounded, Worker-isolate in-memory limiter for traffic shedding. It skips requests without `CF-Connecting-IP`; Turnstile and one-time tokens remain the connection authorization controls.
 10. **Tailwind is built locally** - `frontend/postcss.config.cjs` and `frontend/tailwind.config.cjs` generate Tailwind CSS during Vite builds. Do not reintroduce `cdn.tailwindcss.com`; keep content scan paths and theme variable mappings synchronized when adding frontend source locations or theme tokens.
 11. **Builds never install dependencies** - run `pnpm install --frozen-lockfile` before build/deploy. `scripts/build-html.js` requires exactly one JS and one CSS bundle so every production asset is inlined deterministically.
-12. **Server list organization** - server tags are stored as normalized JSON in SQLite, filtered client-side, and rendered with 9 items per page. Search/tag changes must reset pagination to page 1.
+12. **Server list organization** - server tags are stored as normalized JSON in SQLite, filtered client-side, and rendered with responsive pagination（桌面端每页 9 张、平板 6 张、移动端 3 张，三档常量见 `frontend/src/server-list.ts`）。Search/tag changes must reset pagination to page 1.
 13. **SFTP selection model** - file selection supports single, Cmd/Ctrl toggle, Shift range and select-all. Batch download reuses the sequential download queue; batch delete waits for all delete/rmdir results before refreshing.
 14. **Agent terminal selection context** - “Ask AI assistant” attaches one immutable selection snapshot per tab and never sends it by itself. New selections replace the pending snapshot; successful sends and session teardown clear it. Preserve the untrusted-data/non-authorization boundary in `terminal-selection-context.ts`.
 15. **Region inference privacy** - Saving or changing a Cloudflare-direct server host calls the third-party IPinfo service and persists the inferred locationHint. Servers with `jump_server_id` are downstream nodes: never query their hosts, ignore and clear their own region hints, and infer once if they later become direct Auto entries. Keep the provider name and disclosure synchronized across README/code comments; failures must continue to fall back to Cloudflare's default placement.
@@ -264,9 +313,15 @@ release: 发布新版本
 21. **GitHub access policy** - `GITHUB_ALLOWED_USER_IDS` contains stable numeric GitHub IDs and is rechecked during OAuth callback and every session verification; omitted means unrestricted, while an empty or malformed configured value fails closed. `REQUIRE_GITHUB_AUTH=true` disables anonymous SSH and requires a valid session for direct and one-time-token SSH upgrades, but does not terminate already established WebSockets. Never expose the allowlist through `/api/config`.
 22. **SSH jump chains** - Jump hosts are available only to signed-in users through saved-server `jump_server_id` relations. Resolve one immutable outer-to-target chain in UserDBDO, reject cross-user references, cycles, deletion of referenced hops, and more than 3 jump hosts. Apply public-address SSRF checks only to the outermost Cloudflare TCP destination; anonymous clients must never inject `jumpHosts`. Every intermediate SSHSession authenticates without opening a Shell and exposes only RFC 4254 `direct-tcpip`; terminal, SFTP, Agent exec, and OS detection belong to the final session. Preserve nested channel backpressure, close the full chain on any-hop failure, and scope known-host identities by the complete route so equal private addresses behind different bastions do not collide.
 23. **SSH host-key TOFU** - Never publish or persist a first-seen/replacement fingerprint before its KEX host-key signature succeeds. A changed fingerprint must close normally without automatic retry, display the old/new values for explicit user confirmation, and replace only the exact route-scoped identity. Saved-server confirmation must update the cloud record before requesting a fresh one-time token; anonymous confirmation may update only the current in-memory config and local record. Cancellation or persistence failure must leave the previous trust record intact.
-25. **Command snippets** - 按 `user_id` 行级隔离存于 UserDBDO（名称≤50、命令≤2000、每用户≤100 条），所有 CRUD 均 `WHERE user_id = ?`；匿名用户降级 `localStorage`（`cloudssh_snippets`）。插入默认不自动回车（`insertSnippet` 单行走 `fillInput`、多行走 `xterm paste`），一次性分享会话中隐藏入口。
+24. **Command snippets** - 按 `user_id` 行级隔离存于 UserDBDO（名称≤50、命令≤2000、每用户≤100 条），所有 CRUD 均 `WHERE user_id = ?`；匿名用户降级 `localStorage`（`cloudssh_snippets`）。插入默认不自动回车（`insertSnippet` 单行走 `fillInput`、多行走 `xterm paste`），一次性分享会话中隐藏入口。
 
-24. **One-time SSH sharing** - Sharing is disabled unless `ENABLE_SSH_SHARING=true`. A link contains only a 256-bit capability, persists only its hash, can be claimed once, and exchanges for a one-minute connection ticket. Creation requires route-scoped verified host fingerprints for the target and every jump hop. Share policy is issued only by SSHShareDO/UserDBDO and must disable Agent, OS detection, host-key mutation, metadata mutation, keyboard-interactive auth, and reconnect while permitting only Terminal and optional SFTP. Record lifecycle, structured SFTP requests/results, and terminal output (not raw keystrokes); stop the session if audit storage fails or reaches 5 MiB/5000 events. Revocation and expiry must close the live SSHSessionDO. Preserve completed audit metadata if its saved-server record is later deleted.
+25. **One-time SSH sharing** - Sharing is disabled unless `ENABLE_SSH_SHARING=true`. A link contains only a 256-bit capability, persists only its hash, can be claimed once, and exchanges for a one-minute connection ticket. Creation requires route-scoped verified host fingerprints for the target and every jump hop. Share policy is issued only by SSHShareDO/UserDBDO and must disable Agent, OS detection, host-key mutation, metadata mutation, keyboard-interactive auth, and reconnect while permitting only Terminal and optional SFTP. Record lifecycle, structured SFTP requests/results, and terminal output (not raw keystrokes); stop the session if audit storage fails or reaches 5 MiB/5000 events. Revocation and expiry must close the live SSHSessionDO. Preserve completed audit metadata if its saved-server record is later deleted.
+
+26. **DNS rebinding SSRF defense** - Address-string checks (`isBlockedHost` / `validateBaseUrl`) alone can be bypassed by domains resolving to private/reserved IPs. `src/worker/dns-check.ts` resolves hostnames via DNS-over-HTTPS (1.1.1.1) and checks every resolved IP against a unified block list covering IPv6 edge cases; it gates both SSH outbound targets (`durable-object.ts`) and AI `base_url` (`agent/ssrf.ts`). When adding address families or reserved ranges, keep the DoH block list and the string-level checks synchronized.
+
+27. **Biome formatting convention** - `biome.json`（single 引号、`lineWidth: 100`）自 v1.10.0 起是代码格式基准，相关 lint 规则（`noUnusedVariables`/`useConst` 等）应保持通过；CI 质量门禁不执行 Biome，以 `typecheck` + `test` + 可复现构建 + E2E 为准。
+
+28. **Frontend i18n** - 所有面向用户的文案走 `frontend/src/i18n` 的 `t()` / `data-i18n` / `data-i18n-title` / `data-i18n-placeholder` 管线并同步 `locales/zh-CN.ts` 与 `en-US.ts`；语言解析支持 URL 参数、localStorage（`cloudssh_locale`）与浏览器语言回退。新增文案时保持两端词条对齐，勿硬编码中文到模板字符串。
 
 ## Deployment Notes
 
@@ -275,7 +330,7 @@ release: 发布新版本
 项目支持 production 和 test 两个独立环境同时运行在 Cloudflare 上：
 
 | 环境 | Worker 名称 | 分支 | 域名 |
-|------|------------|------|------|
+| ------ | ------------ | ------ | ------ |
 | Production | `cloudssh` | `main` | `<name>.workers.dev` + 自定义域名 |
 | Test | `cloudssh-test` | `test` | `<name>-test.workers.dev` + 自定义域名 |
 
@@ -284,6 +339,7 @@ release: 发布新版本
 ### 部署方式
 
 **方式一：Cloudflare Dashboard（推荐）**
+
 1. 构建前端：`pnpm run build:frontend`
 2. 进入 Cloudflare Dashboard → Workers
 3. 创建/选择 worker（production 用 `cloudssh`，test 用 `cloudssh-test`）
@@ -292,24 +348,32 @@ release: 发布新版本
 6. 如需自定义域名，在 Settings → Domains & Routes 中绑定
 
 **方式二：Wrangler CLI**
+
 ```bash
 pnpm run deploy          # 部署 production
 pnpm run deploy:test     # 部署 test 环境
 ```
 
 **方式三：GitHub Actions（CI/CD）**
+
 - `test` 分支 push → 自动部署到 `cloudssh-test`
 - `main` 分支 push → 自动部署到 `cloudssh`
+- `docs/**` 变更 → 发布 GitHub Pages 主题编辑器（`github-pages.yml`）
+- Fork 定时同步上游 `main`（`sync-upstream.yml`，默认关闭，由 `AUTO_SYNC_UPSTREAM` 仓库变量开启）
+
+> 部署门禁（`deploy.yml`）依次执行：冻结锁文件安装 → Playwright 浏览器安装 → `typecheck` → `test` → `build:frontend` → `test:e2e` → 按分支部署；任一环节失败即阻断部署。
 
 ### 自定义域名
 
 `wrangler.toml` 中不硬编码自定义域名（开源项目，每人域名不同）。默认使用 Cloudflare 提供的 `workers.dev` 域名。如需绑定自定义域名：
+
 - 在 Cloudflare Dashboard → Workers → 你的 Worker → Settings → Domains & Routes 中添加
 - 或在 `wrangler.toml` 中添加 `[[routes]]` 配置（仅本地使用，勿提交到仓库）
 
 ### Secrets 配置
 
 通过 Cloudflare Dashboard 或 wrangler CLI 设置：
+
 - `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET` - GitHub OAuth
 - `GITHUB_ALLOWED_USER_IDS` - 可选，逗号分隔的 GitHub 数字用户 ID 白名单
 - `REQUIRE_GITHUB_AUTH` - 可选，设为 `true` 时禁用匿名 SSH 并要求有效 GitHub session
@@ -349,8 +413,10 @@ CLI: `npx wrangler secret set <SECRET_NAME>`
       - 正文必须说明本次版本的更新内容：包含提交列表、关联 Issue/PR、验证结果。
    3. **PR 的审核与合并由用户手动完成**：AI 创建 PR 后应等待用户审核并合并，不得自行合并或使用管理员旁路合并。
    4. 用户合并 PR 到 `main` 后（生产环境自动部署），AI 执行以下命令同步本地分支：
+
       ```bash
       git fetch origin && git reset --hard origin/main && git push origin test --force
       ```
+
       - 该操作使本地 `test` 分支与已发布的 `main` 完全一致。
       - 若此前还有未发布的 `test` 提交，会被强制覆盖，请确认已合并完成后再执行。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -323,6 +323,8 @@ release: 发布新版本
 
 28. **Frontend i18n** - 所有面向用户的文案走 `frontend/src/i18n` 的 `t()` / `data-i18n` / `data-i18n-title` / `data-i18n-placeholder` 管线并同步 `locales/zh-CN.ts` 与 `en-US.ts`；语言解析支持 URL 参数、localStorage（`cloudssh_locale`）与浏览器语言回退。新增文案时保持两端词条对齐，勿硬编码中文到模板字符串。
 
+29. **CI paths-ignore 作用域** - `deploy.yml` 的 `paths-ignore` 使用标准 glob：`*` 不匹配 `/`，因此 `*.md` 只覆盖仓库根目录的 Markdown，`tests/` 等子目录下的文档变更（如 `tests/README.md`）会照常触发部署流水线。忽略目录内文件必须用 `**/*.md` / `**/*.png` 等跨目录模式；修改 `deploy.yml` 本身会触发一次校验运行（属于预期行为，且能验证新过滤规则）。
+
 ## Deployment Notes
 
 ### 双环境部署

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.10.2] - 2026-08-20
+
+### Changed
+
+- 精简 README 结构：核心优势要点化（重点、全面不啰嗦）；架构说明仅保留系统架构图，移除核心组件 / SSH 协议实现 / 数据流三个小节；快速部署移除本地命令行部署方式，中英文档同步调整。
+- 快速部署新增「可配置环境变量」汇总表，涵盖 GitHub OAuth、登录白名单、强制登录、一次性分享、Turnstile、主机密钥验证与调试模式等全部可配置变量。
+- 更新文档配套内容：演示视频时长（8:27 → 19:48）；`AGENTS.md` 目录树补齐前端/后端新模块、环境变量、tests/ 结构与 5 条新坑位（DNS 防重绑定、Biome 约定、i18n、CI 作用域等）；`tests/README.md` 补充 7 个新测试文件与覆盖范围。
+
+### Fixed
+
+- 修复 GitHub Actions 部署工作流 `paths-ignore` 作用域：标准 glob 的 `*` 不匹配 `/`，原 `*.md` 只忽略仓库根目录文档，导致 `tests/README.md` 等子目录文档变更误触发完整部署流水线；改为 `**/*.md`、`**/*.png` 等跨目录模式。
+
 ## [1.10.1] - 2026-08-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
     <br/>
     <img src="https://img.shields.io/badge/%E2%96%B6_%E7%82%B9%E5%87%BB%E6%92%AD%E6%94%BE%E8%A7%86%E9%A2%91-00A1D6?style=for-the-badge&logo=bilibili&logoColor=white" alt="播放" />
   </a>
-  <p><sub>视频时长 8:27 · 演示 CloudSSH 完整使用流程</sub></p>
+  <p><sub>视频时长 19:48 · 演示 CloudSSH 完整使用流程</sub></p>
 </div>
 
 ## 目录
@@ -48,7 +48,7 @@
 - [快速部署](#quick-start)
   - [GitHub 绑定自动部署](#方式一通过-github-绑定自动部署推荐)
     - [自动同步上游版本](#可选自动同步上游版本)
-  - [本地命令行部署](#方式二本地命令行部署)
+  - [可配置环境变量](#可配置环境变量)
   - [配置 Turnstile](#可选配置-turnstile-人机验证)
   - [配置 GitHub OAuth](#可选配置-github-oauth-登录与服务器管理)
 - [开发说明](#development)
@@ -63,22 +63,21 @@
 
 ### 极致 Serverless
 
-- **零服务器成本**：纯前端部署 + Cloudflare Workers，无需自建后端服务器。
-- **边缘加速**：得益于 Cloudflare 的全球边缘网络，随时随地享受低延迟的 SSH 连接。
+- **零服务器成本**：纯前端 + Cloudflare Workers，无需自建后端服务器。
+- **边缘加速**：全球边缘网络就近接入，随时随地享受低延迟的 SSH 连接。
 
 ### 开箱即用
 
-- **一键部署**：仅需Fork本仓库，再在 Cloudflare Dashboard 点击几下即可完成项目构建与部署。
-- **现代化前端技术栈**：TypeScript + Vite + Tailwind CSS，配合 xterm.js 提供丝滑的终端体验。
+- **一键部署**：Fork 仓库后在 Cloudflare Dashboard 绑定 GitHub 即可自动构建部署，无需本地环境。
+- **现代技术栈**：TypeScript + Vite + Tailwind CSS + xterm.js，兼顾性能与可维护性。
 
 ### 安全可靠
 
-- **分段加密传输**：浏览器与 Cloudflare Worker 之间使用 HTTPS/WSS，Worker 与目标主机之间使用完整的 SSH-2.0 协议；SSH 段支持 Curve25519-SHA256（优先）和 ECDH-NISTP256 密钥交换、AES-256-GCM（优先）/ AES-128-GCM / AES-256-CTR 数据加密，以及 HMAC-SHA2-256/512 完整性校验。
-- **多算法主机密钥验证**：支持 Ed25519、ECDSA P-256/P-384/P-521、RSA 签名验证，首次连接展示 SHA-256 指纹（TOFU 模式）。
-- **安全加固体系**：内置针对 IPv6 与保留地址的 SSRF 防护；`/api/ssh` 使用有界的 Worker 实例内存限流进行流量削峰，连接授权仍由 Turnstile 或一次性连接令牌负责；已保存的服务器凭据在每用户 Durable Object SQLite 中使用 AES-256-GCM 加密存储。
-- **人机验证**：支持 Cloudflare Turnstile 验证，防止恶意机器人滥用。
-- **隔离的会话状态**：每个 SSH 终端会话由独立的 Cloudflare Durable Object 管理；浏览器侧 WebSocket 使用 Hibernation API 接入方式，但活动的 SSH 出站 TCP 连接会使该 Durable Object 在会话期间保持唤醒。
-- **已保存凭据内部流转**：一键连接已保存服务器时，凭据由 UserDBDO 在服务端解密，并通过一次性连接令牌在 Worker 与 SSHSessionDO 之间传递；浏览器不会收到明文凭据。匿名连接或首次保存服务器时，用户输入仍会通过 HTTPS/WSS 发送到 Worker。
+- **双段加密**：浏览器 ↔ Worker 走 HTTPS/WSS；Worker ↔ 服务器走完整 SSH-2.0 协议（Curve25519-SHA256/ECDH-NISTP256 密钥交换、AES-256-GCM/CTR 加密、HMAC-SHA2 完整性校验）。
+- **主机指纹验证**：Ed25519/ECDSA P-256/P-384/P-521/RSA 签名校验，首次连接展示 SHA-256 指纹（TOFU）。
+- **多层防护**：IPv6/保留地址 SSRF + DNS 防重绑定、Worker 内存限流削峰、Turnstile 人机验证；已保存凭据在每用户 SQLite 中以 AES-256-GCM 加密存储。
+- **会话隔离**：每个终端会话由独立 Durable Object 管理，活动 SSH TCP 连接使会话保持唤醒。
+- **凭据内部流转**：一键连接时服务端解密凭据并经一次性令牌内部传递到会话，浏览器全程不接触明文。
 
 <a id="features"></a>
 
@@ -98,10 +97,12 @@
 - **个性化 UI**：Theme V2 系统提供 Standard Dark、Standard Light、Cyberpunk、Glacier、Gruvbox 五款内置主题。配套 [GitHub Pages 主题编辑器](https://newbietan.github.io/CloudSSH/)可实时调整颜色、形状、密度、字体、阴影、动效及按钮/输入框/卡片/标签页样式，并预览登录页、服务器列表、终端 + SFTP 和 AI Agent 面板。主题通过 JSON 文件导入、导出、备份与分享；登录用户在应用中导入后会同步到账号并可跨浏览器恢复，匿名用户仅保存在当前浏览器。
 - **SFTP 图形化文件管理**：集成完整的 SFTP v3 文件传输协议，提供图形化文件浏览器界面。支持目录浏览、文件上传/下载、新建文件夹、文件重命名与删除等操作；支持普通单选、`Cmd/Ctrl` 切换选择、`Shift` 连选、全选，以及批量下载文件和批量删除。基于 SSH 子系统实现，与终端会话并行运行，互不干扰，支持下载队列及上传取消。
 - **原生文件传输**：集成 [trzsz.js](https://github.com/trzsz/trzsz.js)，支持 `trz`（上传）/ `tsz`（下载）命令进行文件传输，兼容 tmux 会话。还支持拖拽文件到终端窗口直接上传、目录传输及断点续传等高级功能。（需远程服务器安装 [trzsz](https://trzsz.github.io/)）
-- **GitHub OAuth 集成**：支持 GitHub 登录，用户可保存和管理常用 SSH 服务器，实现一键连接；服务器支持最多 10 个规范化标签，列表可按名称、主机地址、用户名即时搜索并按标签筛选，每页固定展示 9 张服务器卡片。
+- **中英文界面**：内置简体中文与英文两套 UI 词条，自动跟随浏览器语言并提供手动切换，选择通过 URL 参数或本地存储（`cloudssh_locale`）持久化。
+- **GitHub OAuth 集成**：支持 GitHub 登录，用户可保存和管理常用 SSH 服务器，实现一键连接；服务器支持最多 10 个规范化标签，列表可按名称、主机地址、用户名即时搜索并按标签筛选，分页随设备自适应（桌面每页 9 张、平板 6 张、移动端 3 张卡片）。
+- **自定义命令片段库**：登录用户可将常用命令按名称保存为片段并通过服务端搜索复用，片段按 `user_id` 行级隔离存储于 `UserDBDO`（名称≤50、命令≤2000、每用户≤100 条），匿名用户自动降级到本地 `localStorage`；支持填入终端、填入并执行、编辑与删除，桌面与移动端均可在工具栏访问，一次性分享会话中自动隐藏。
 - **服务器系统自动识别**：登录用户首次连接尚未识别的已保存服务器时，CloudSSH 会在终端就绪后通过独立 SSH exec 通道读取 `/etc/os-release` 或 `uname`，并在服务器卡片显示对应系统图标。检测在后台执行，不阻塞终端；只有成功识别的结果才会保存，未识别结果会留待下次连接重新探测，修改主机地址或端口也会清除旧结果。匿名连接不执行该检测。该只读命令可能出现在目标服务器的 SSH 审计日志中。
 - **IP 隐私展示与快捷复制**：服务器列表和连接状态栏会对有效 IPv4/IPv6 地址进行视觉掩码，减少演示或截图时意外暴露完整地址的风险；可通过鼠标点击或键盘操作复制用于连接的完整 IP。域名保持原样显示，视觉掩码不等同于加密或访问控制。
-- **单页面多标签会话管理**：支持在单个页面内开启与切换多个独立的 SSH 终端与 SFTP 文件管理器，各会话环境和状态完全隔离，并在个性化主题编辑器中进行了联动适配。
+- **单页面多标签会话管理**：支持在单个页面内开启与切换多个独立的 SSH 终端与 SFTP 文件管理器，各会话环境和状态完全隔离，并在个性化主题编辑器中进行了联动适配。进入服务器列表或匿名连接页后可随时通过工具栏/表单顶部按钮一键返回已建立的 SSH 会话，终端界面隐藏时也可直接按 `Esc` 快速返回；按钮随标签数量联动显隐。
 - **安全匿名历史记录**：本地存储最近 5 条匿名连接，且敏感凭证可选使用本地派生的密钥进行 AES-256-GCM 安全加密存储至 `localStorage`，提供一键回填与清除。
 - **双段延迟与 Colo 展示**：状态栏即时且周期性地展示当前 RTT（客户端至 Cloudflare）、物理延迟（Cloudflare 至主机）以及 Cloudflare 当前服务的数据中心代码（如 `CF-LAX`），并通过绿、黄、红三色状态点提示网络质量。
 - **智能区域调度（locationHint）**：保存直连服务器时通过 IPinfo 查询主机地理信息并持久化 DO 部署区域，连接时直接读取数据库，不再执行外部地理查询；使用 SSH 跳板时仅对 Cloudflare 直接连接的最外层入口进行推断，下游内网服务器不会触发查询，其区域设置由入口统一决定。查询失败时自动退化为 Cloudflare 默认调度，也可为直连入口手动覆盖区域偏好。_注意：自动推断会把直连入口的主机信息发送给第三方 IPinfo；locationHint 是 Cloudflare 的 best-effort 特性，当目标区域 DO 容量不足时会 fallback 到最近可用区域。_
@@ -150,62 +151,6 @@ flowchart TB
     AgentCore <-->|"LLM API"| External["外部 LLM 服务"]
 ```
 
-### 核心组件
-
-| 组件                 | 文件                                                  | 职责                                                                                                                            |
-| -------------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| **Worker 入口**      | `src/worker/index.ts`                                 | HTTP 路由、API 处理、WebSocket 升级                                                                                             |
-| **SSHSessionDO**     | `src/worker/durable-object.ts`                        | SSH 会话生命周期管理、SSRF 防护                                                                                                 |
-| **UserDBDO**         | `src/worker/user-db.ts`                               | 按 GitHub 用户隔离的用户数据、Session、服务器配置、规范化标签与凭据存储（SQLite）                                               |
-| **SSHShareDO**       | `src/worker/share-do.ts`                              | 一次性能力凭证、短期连接票据、过期/撤销状态以及分享会话专用审计日志                                                       |
-| **IP 地理推断**      | `src/worker/ip-geo.ts`                                | 保存 Cloudflare 直连入口时推断其 IP 所在区域，映射到 Cloudflare DO locationHint；跳板链下游节点不查询                           |
-| **操作系统识别**     | `src/worker/os-detect.ts`                             | 解析远端系统标识、规范化可持久化 OS key                                                                                         |
-| **SSHSession**       | `src/worker/ssh-session.ts`                           | SSH 协议状态机（连接→版本→密钥交换→认证→交互）                                                                                  |
-| **SSH 跳板字节流**   | `src/worker/direct-tcpip-stream.ts`                   | 将 RFC 4254 `direct-tcpip` 通道封装为可嵌套 SSH 的背压双向字节流                                                               |
-| **SSH 协议栈**       | `src/ssh/*.ts`                                        | 纯 TypeScript SSH-2.0 实现（传输层、加密、认证、通道）                                                                          |
-| **SFTP 处理器**      | `src/worker/sftp-handler.ts`                          | SFTP 协议操作、任务队列、并发下载、上传跟踪与取消支持                                                                           |
-| **SFTP 协议实现**    | `src/ssh/sftp.ts` / `sftp-types.ts`                   | SFTP v3 协议客户端、包解析与类型定义                                                                                            |
-| **前端终端**         | `frontend/src/terminal.ts`                            | xterm.js 封装、原生右键粘贴、实时双段延迟心跳、网络质量三色提示、终端搜索、选区询问 Agent 及 WebSocket 交互                     |
-| **移动端控制器**     | `frontend/src/mobile-terminal.ts` / `mobile-input.ts` | 动态视口、iOS IME 补偿、触摸快捷键、剪贴板操作及可选全屏横屏                                                                    |
-| **标签管理器**       | `frontend/src/tab-manager.ts`                         | 单页面多会话标签页管理器，协调不同标签页内的终端、SFTP 与 Agent 实例及上下文隔离，并展示可复制的掩码 IP                         |
-| **服务器列表**       | `frontend/src/server-list.ts`                         | 服务器卡片管理、搜索、标签筛选、IP 隐私展示及每页 9 项分页                                                                      |
-| **SSH 分享界面**     | `frontend/src/share-manager.ts` / `share-session.ts`  | 所有者创建、撤销与查看审计；接收者显式确认审计后一次性领取分享会话                                                     |
-| **主机地址展示**     | `frontend/src/host-display.ts`                        | 校验 IPv4/IPv6 字面量并生成统一的隐私掩码文本                                                                                   |
-| **SFTP 面板**        | `frontend/src/sftp-panel.ts`                          | 图形化文件管理器 UI，支持多选、批量下载/删除、上传下载队列和取消操作                                                            |
-| **AI Agent**         | `src/worker/agent/core.ts`                            | AI 控制循环：LLM 流式调用、工具执行、环境探测、终端上下文读取                                                                   |
-| **Agent 工具**       | `src/worker/agent/tools.ts`                           | 8 个运维工具定义（执行命令、终端上下文、环境探测、进程列表、服务管理、Docker 管理、用户确认、报告输出）                         |
-| **Agent 安全**       | `src/worker/agent/safety.ts`                          | 两层安全策略：直接拦截（rm -rf /、fork bomb 等）+ 弹窗确认（rm、shutdown、iptables 等）                                         |
-| **Agent 面板**       | `frontend/src/agent/agent-panel.ts`                   | AI 助手侧边栏 UI，支持终端选区上下文附件、流式输出、Markdown 渲染、代码块复制与安全填入终端、可折叠思考过程容器和安全确认对话框 |
-| **Agent 选区上下文** | `frontend/src/agent/terminal-selection-context.ts`    | 保留终端选区快照、统计展示信息，并将用户问题与非授权安全边界组合为模型请求                                                      |
-| **AI 配置**          | `frontend/src/ai-config.ts`                           | AI 模型配置弹窗，支持 Base URL / API Key / 模型选择                                                                             |
-| **区域选项**         | `frontend/src/regions.ts`                             | DO locationHint 区域选项共享组件，供服务器管理和匿名连接表单共用                                                                |
-
-### SSH 协议实现
-
-本项目实现了完整的 SSH-2.0 协议栈：
-
-| 层级           | 实现                                | 支持算法                                                      |
-| -------------- | ----------------------------------- | ------------------------------------------------------------- |
-| **密钥交换**   | `kex-curve25519.ts` / `kex-ecdh.ts` | curve25519-sha256, ecdh-sha2-nistp256                         |
-| **数据加密**   | `crypto.ts`                         | aes256-gcm, aes128-gcm, aes256-ctr, aes192-ctr, aes128-ctr    |
-| **完整性校验** | `crypto.ts`                         | hmac-sha2-256, hmac-sha2-512, hmac-sha1                       |
-| **主机密钥**   | `ssh-session.ts`                    | Ed25519, ECDSA P-256/P-384/P-521, RSA                         |
-| **用户认证**   | `auth.ts`                           | 密码、RFC 4256 keyboard-interactive；Ed25519、ECDSA P-256/P-384/P-521、RSA-SHA2 私钥认证 |
-| **通道管理**   | `channel.ts`                        | session、`direct-tcpip`、SFTP subsystem、PTY、shell、window-change |
-| **SFTP 协议**  | `sftp.ts` / `sftp-types.ts`         | SFTP v3 文件传输协议（目录浏览、上传、下载、删除、重命名）    |
-
-### 数据流
-
-1. 用户在前端输入主机 IP、账号和密码（或通过 GitHub OAuth 选择已保存的服务器）。
-2. 前端与后端的 Durable Object 建立 WebSocket 连接。
-3. SSHSessionDO 接收凭据，使用 `@cloudflare/sockets` 与直连目标或最外层跳板建立 TCP 连接。
-4. 如配置跳板，SSHSession 逐层认证并通过 RFC 4254 `direct-tcpip` 通道承载下一套 SSH；仅最终目标打开 PTY、Shell、SFTP 与 Agent exec 通道。
-5. 终端数据在浏览器与 Worker 之间通过 WSS 传输，在 Worker 与目标服务器之间通过 SSH 加密传输；Worker 负责两段协议之间的转发和 SSH 协议处理。
-6. SFTP 文件管理通过独立的 SSH 子系统通道运行，支持目录浏览、文件上传/下载等操作。
-7. 对尚无 OS 记录的已保存服务器，SSHSession 在 Shell 就绪后通过独立 exec 通道进行一次只读系统识别；成功结果写入 UserDBDO 并通知前端更新卡片，未知结果不保存。
-8. AI 助手通过 WebSocket 接收用户问题及可选的终端选区上下文；选区被标记为非可信分析数据后交给 AgentCore，后者调用外部 LLM API，通过 SSH exec 通道执行获准的命令，并将结果流式返回前端。
-9. 一次性分享链接先由 SSHShareDO 原子领取并换取短期连接票据；分享会话的生命周期、SFTP 操作和终端输出写入独立审计库，失效、撤销或审计不可用时终止连接。
-
 <a id="quick-start"></a>
 
 ## 快速部署
@@ -247,41 +192,22 @@ Fork 仓库可以通过内置的 `Sync upstream` GitHub Actions 工作流，定�
 
 > **同步说明**：工作流使用 GitHub 提供的 Fork 同步接口，不需要 PAT，也不会强制覆盖分支。若你的 `main` 与上游存在无法自动合并的冲突，任务会失败并保留现有代码，需要手动解决冲突。建议不要直接修改部署用的 `main` 分支，并将域名、密钥及环境变量保存在 Cloudflare Dashboard 中。
 
-#### 方式二：本地命令行部署
+#### 可配置环境变量
 
-1. **克隆仓库**
+所有可选功能均由 Worker 环境变量控制，可在 Cloudflare Dashboard 的 Settings → Variables and Secrets 中添加（敏感项建议选择 **Secret** 类型），保存后重新部署生效：
 
-   ```bash
-   git clone https://github.com/newbietan/CloudSSH.git
-   cd CloudSSH
-   ```
+| 环境变量 | 必填 | 说明 |
+| --- | --- | --- |
+| `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET` | 启用 GitHub 登录时必填 | GitHub OAuth 应用凭据 |
+| `BASE_URL` | 启用 GitHub 登录时必填 | OAuth 回调地址，需与实际部署域名一致 |
+| `GITHUB_ALLOWED_USER_IDS` | 可选 | 允许登录的 GitHub 数字用户 ID 白名单（逗号分隔）；未配置不限制，配置为空或非正整数时 fail-closed |
+| `REQUIRE_GITHUB_AUTH` | 可选 | 设为 `true` 时禁用匿名 SSH，所有连接均要求有效 GitHub 登录 |
+| `ENABLE_SSH_SHARING` | 可选 | 设为 `true` 时启用一次性 SSH 分享（默认关闭） |
+| `TURNSTILE_SECRET` / `TURNSTILE_SITEKEY` | 可选 | Cloudflare Turnstile 人机验证密钥 |
+| `STRICT_HOST_KEY_VERIFY` | 可选 | 主机密钥签名验证：设为 `false` 跳过验证失败（默认 `true`，fail-closed） |
+| `DEBUG_MODE` | 可选 | 设为 `true` 时输出调试信息（`wrangler.toml` 默认 `false`） |
 
-2. **安装依赖**
-
-   ```bash
-   npm install -g pnpm
-   pnpm install
-   cd frontend && pnpm install
-   ```
-
-3. **登录 Cloudflare**
-
-   ```bash
-   npx wrangler login
-   ```
-
-4. **部署生产环境**
-
-   ```bash
-   pnpm run deploy
-   ```
-
-5. **部署测试环境**（可选）
-   ```bash
-   pnpm run deploy:test
-   ```
-
-> **说明**：两个环境的 Durable Objects 虽然绑定相同的 class_name，但因 Worker 名称不同，数据完全隔离。部署完成后可在 Cloudflare Dashboard 中分别绑定不同的自定义域名（Settings → Domains & Routes）。
+> **说明**：如需本地命令行部署或调试 Worker，请参考 [开发说明](#development) 中的本地开发部分。
 
 #### 可选：配置 Turnstile 人机验证
 
@@ -331,14 +257,14 @@ Fork 仓库可以通过内置的 `Sync upstream` GitHub Actions 工作流，定�
 
    请填写 `id`，不要填写用户名或 `node_id`。数字 ID 不会随用户名修改而变化；多个账号的 ID 使用英文逗号分隔。
 
-   | 配置组合 | GitHub 登录 | 匿名 SSH |
-   |----------|-------------|----------|
-   | 两项都不配置 | 所有 GitHub 用户 | 允许 |
-   | 仅配置 `GITHUB_ALLOWED_USER_IDS` | 仅白名单用户 | 允许 |
-   | 仅配置 `REQUIRE_GITHUB_AUTH=true` | 所有 GitHub 用户 | 禁止 |
-   | 两项同时配置 | 仅白名单用户 | 禁止（私有实例模式） |
+| 配置组合 | GitHub 登录 | 匿名 SSH |
+| ---------- | ------------- | ---------- |
+| 两项都不配置 | 所有 GitHub 用户 | 允许 |
+| 仅配置 `GITHUB_ALLOWED_USER_IDS` | 仅白名单用户 | 允许 |
+| 仅配置 `REQUIRE_GITHUB_AUTH=true` | 所有 GitHub 用户 | 禁止 |
+| 两项同时配置 | 仅白名单用户 | 禁止（私有实例模式） |
 
-3. **重新部署**：保存环境变量后重新部署当前 Worker。仓库中的 Durable Object migration 会负责初始化所需类和数据库，不需要删除已有 Worker。
+1. **重新部署**：保存环境变量后重新部署当前 Worker。仓库中的 Durable Object migration 会负责初始化所需类和数据库，不需要删除已有 Worker。
 
 > **环境变量类型建议**：`GITHUB_CLIENT_SECRET` 必须使用 **Secret** 类型；`GITHUB_ALLOWED_USER_IDS` 和 `REQUIRE_GITHUB_AUTH` 不包含密钥，可使用普通文本变量。Secrets 存储在 Cloudflare 加密存储中，与代码部署分离，重新部署时不会被覆盖或丢失。
 
@@ -382,15 +308,20 @@ CloudSSH/
 ├── src/                    # 后端源码 (Cloudflare Worker)
 │   ├── ssh/                # SSH 协议纯实现层（传输、加密、认证、通道、SFTP）
 │   └── worker/             # Worker 入口和 Durable Objects
-│       └── agent/          # AI Agent 控制循环、工具、安全检测
+│       ├── agent/          # AI Agent 控制循环、工具、安全检测
+│       ├── dns-check.ts    # DNS 防重绑定 SSRF 防护
+│       └── ip-geo.ts       # IPinfo 区域推断 → locationHint
 ├── frontend/               # 前端源码 (独立 workspace)
 │   └── src/                # TypeScript + xterm.js + trzsz
-│       └── agent/          # AI 助手侧边栏 UI
+│       ├── agent/          # AI 助手侧边栏 UI
+│       └── i18n/           # 中英文词条与语言解析
 ├── docs/                   # GitHub Pages 静态资源
 │   └── theme-editor/       # 可视化主题编辑器
 ├── scripts/                # 构建脚本
-├── tests/                  # Vitest、Playwright 与 axe 回归测试
-├── .github/workflows/      # CI/CD 自动部署配置
+├── tests/                  # Vitest 单元/集成 + Playwright E2E 与 axe 回归（build/ e2e/ ssh/ worker/）
+├── .github/workflows/      # CI/CD 自动部署配置（deploy / github-pages / sync-upstream）
+├── biome.json              # 代码格式与 lint 约定
+├── playwright.config.ts    # 浏览器 E2E 测试配置
 ├── pnpm-workspace.yaml     # pnpm 工作区配置
 └── wrangler.toml           # Cloudflare 部署配置
 ```
@@ -449,15 +380,15 @@ pnpm run dev
 
 #### 常用开发命令
 
-| 命令                      | 说明                                         |
+| 命令 | 说明 |
 | ------------------------- | -------------------------------------------- |
-| `pnpm run dev`            | 构建前端 + 启动 Wrangler 开发服务器          |
-| `pnpm run build:frontend` | 仅构建前端（输出到 `frontend/dist/`）        |
-| `pnpm run typecheck`      | 检查 Worker 与前端 TypeScript 类型           |
-| `pnpm test`               | 运行 Vitest 单元与集成测试                   |
-| `pnpm run test:e2e`       | 运行 Playwright 浏览器 E2E 与 axe 无障碍测试 |
-| `pnpm run verify`         | 依次执行类型检查、测试、生产构建和浏览器 E2E |
-| `pnpm run deploy:test`    | 构建并部署到隔离的测试环境                   |
+| `pnpm run dev` | 构建前端 + 启动 Wrangler 开发服务器 |
+| `pnpm run build:frontend` | 仅构建前端（输出到 `frontend/dist/`） |
+| `pnpm run typecheck` | 检查 Worker 与前端 TypeScript 类型 |
+| `pnpm test` | 运行 Vitest 单元与集成测试 |
+| `pnpm run test:e2e` | 运行 Playwright 浏览器 E2E 与 axe 无障碍测试 |
+| `pnpm run verify` | 依次执行类型检查、测试、生产构建和浏览器 E2E |
+| `pnpm run deploy:test` | 构建并部署到隔离的测试环境 |
 
 #### 提交变更的流程
 
@@ -477,16 +408,17 @@ test 分支（开发/测试）  ──合并──>  main 分支（生产）
 
 ### 技术栈
 
-| 层级         | 技术                                                 | 说明                                                                                         |
+| 层级           | 技术                                                   | 说明                                                                                           |
 | ------------ | ---------------------------------------------------- | -------------------------------------------------------------------------------------------- |
-| **前端**     | TypeScript + Vite + xterm.js                         | Web 终端模拟器，WebGL 硬件加速                                                               |
-| **UI 框架**  | Tailwind CSS（Vite/PostCSS 本地构建）+ Theme V2 系统 | 应用支持内置主题切换、自定义主题 JSON 导入及登录账号同步；主题编辑与导出由 GitHub Pages 提供 |
-| **文件传输** | trzsz.js                                             | 支持 trz/tsz 命令、拖拽上传、断点续传                                                        |
-| **AI 助手**  | BYOK + OpenAI 兼容接口                               | 自带 API Key，支持 DeepSeek 等兼容模型                                                       |
-| **后端**     | Cloudflare Workers                                   | Serverless 边缘计算                                                                          |
-| **会话管理** | Durable Objects                                      | SSH 会话隔离；浏览器 WebSocket 使用 Hibernation API 接入，活动出站 TCP 期间不休眠            |
-| **数据存储** | Durable Objects SQLite                               | 用户数据、服务器配置                                                                         |
-| **包管理**   | pnpm (workspace)                                     | Monorepo 依赖管理                                                                            |
+| **前端**       | TypeScript + Vite + xterm.js                         | Web 终端模拟器，WebGL 硬件加速                                                                         |
+| **国际化**      | 自研轻量 i18n（`frontend/src/i18n`）                       | 简体中文 / English 双语言界面，浏览器语言自动识别与手动切换                                                          |
+| **UI 框架**    | Tailwind CSS（Vite/PostCSS 本地构建）+ Theme V2 系统         | 应用支持内置主题切换、自定义主题 JSON 导入及登录账号同步；主题编辑与导出由 GitHub Pages 提供                                     |
+| **文件传输**     | trzsz.js                                             | 支持 trz/tsz 命令、拖拽上传、断点续传                                                                      |
+| **AI 助手**    | BYOK + OpenAI 兼容接口                                   | 自带 API Key，支持 DeepSeek 等兼容模型                                                                 |
+| **后端**       | Cloudflare Workers                                   | Serverless 边缘计算                                                                              |
+| **会话管理**     | Durable Objects                                      | SSH 会话隔离；浏览器 WebSocket 使用 Hibernation API 接入，活动出站 TCP 期间不休眠                                  |
+| **数据存储**     | Durable Objects SQLite                               | 用户数据、服务器配置                                                                                   |
+| **包管理**      | pnpm (workspace)                                     | Monorepo 依赖管理                                                                                |
 
 <a id="contributors"></a>
 
@@ -494,12 +426,12 @@ test 分支（开发/测试）  ──合并──>  main 分支（生产）
 
 感谢以下贡献者对 CloudSSH 的代码、兼容性和用户体验所做的贡献：
 
-| 贡献者                                              | 主要贡献                                                                                                                 |
-| --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| [TanXin (@newbietan)](https://github.com/newbietan) | 项目发起与持续维护；Cloudflare Serverless、SSH/SFTP、AI Agent、安全体系、主题系统及工程化建设                            |
-| [David xu (@xqdoo00o)](https://github.com/xqdoo00o) | Dropbear 兼容、trzsz 文件传输迁移、PTY 尺寸处理，以及会话退出与重连交互优化                                              |
-| [vonl1 (@vonl1)](https://github.com/vonl1)          | 终端选区自动复制、兼容 Vim 的右键粘贴体验、服务器 IPv4/IPv6 掩码与完整地址快捷复制，以及服务器操作系统自动识别与品牌图标 |
-| [Leon Xu (@xuthuslei)](https://github.com/xuthuslei)    | 修复 `SSH_MSG_NEWKEYS` 与首个加密包同批到达时的加密状态切换和数据包解析兼容问题                                       |
+| 贡献者                                                  | 主要贡献                                                                                                                     |
+| ---------------------------------------------------  | ------------------------------------------------------------------------------------------------------------------------ |
+| [TanXin (@newbietan)](https://github.com/newbietan)  | 项目发起与持续维护；Cloudflare Serverless、SSH/SFTP、AI Agent、安全体系、主题系统及工程化建设                                                        |
+| [David xu (@xqdoo00o)](https://github.com/xqdoo00o)  | Dropbear 兼容、trzsz 文件传输迁移、PTY 尺寸处理，以及会话退出与重连交互优化                                                                          |
+| [vonl1 (@vonl1)](https://github.com/vonl1)           | 终端选区自动复制、兼容 Vim 的右键粘贴体验、服务器 IPv4/IPv6 掩码与完整地址快捷复制，以及服务器操作系统自动识别与品牌图标                                                     |
+| [Leon Xu (@xuthuslei)](https://github.com/xuthuslei) | 修复 `SSH_MSG_NEWKEYS` 与首个加密包同批到达时的加密状态切换和数据包解析兼容问题                                                                        |
 
 名单及贡献说明依据 Git 提交历史与已接收的 Pull Request 整理；同一贡献者在历史中可能使用过不同的 Git 作者名称或邮箱。完整记录请参阅 [GitHub Contributors](https://github.com/newbietan/CloudSSH/graphs/contributors)。欢迎通过 Issue 和 Pull Request 参与项目建设。
 

--- a/README_en.md
+++ b/README_en.md
@@ -37,7 +37,7 @@
     <br/>
     <img src="https://img.shields.io/badge/%E2%96%B6_Click_to_Play_Video-00A1D6?style=for-the-badge&logo=bilibili&logoColor=white" alt="Play" />
   </a>
-  <p><sub>Video duration 8:27 · Full CloudSSH walkthrough</sub></p>
+  <p><sub>Video duration 19:48 · Full CloudSSH walkthrough</sub></p>
 </div>
 
 ## Table of Contents
@@ -48,7 +48,7 @@
 - [Quick Deployment](#quick-start)
   - [GitHub Integration](#method-1-deploy-via-github-integration-recommended)
     - [Automatically Sync Upstream](#optional-automatically-sync-upstream-releases)
-  - [Local CLI Deployment](#method-2-local-cli-deployment)
+  - [Configurable Environment Variables](#configurable-environment-variables)
   - [Configure Turnstile](#optional-configure-turnstile-human-verification)
   - [Configure GitHub OAuth](#optional-configure-github-oauth-login--server-management)
 - [Development](#development)
@@ -58,28 +58,29 @@
 - [License](#license)
 
 <a id="highlights"></a>
+
 ## Highlights
 
 ### Ultimate Serverless
 
-- **Zero Server Cost**: Pure frontend deployment + Cloudflare Workers, no need to build your own backend servers.
-- **Edge Acceleration**: Benefit from Cloudflare's global edge network, enjoying low-latency SSH connections from anywhere.
+- **Zero Server Cost**: Pure frontend + Cloudflare Workers, no backend servers to maintain.
+- **Edge Acceleration**: Cloudflare's global edge network routes connections to the nearest location for low-latency SSH.
 
 ### Out of the Box
 
-- **One-Click Deployment**: Simply fork this repository, then complete the project build and deployment with a few clicks in the Cloudflare Dashboard.
-- **Modern Frontend Stack**: TypeScript + Vite + Tailwind CSS, paired with xterm.js to provide a silky smooth terminal experience.
+- **One-Click Deployment**: Fork the repo and connect GitHub in the Cloudflare Dashboard to build and deploy automatically, no local environment needed.
+- **Modern Tech Stack**: TypeScript + Vite + Tailwind CSS + xterm.js, balancing performance and maintainability.
 
 ### Secure and Reliable
 
-- **Encrypted Transport in Two Segments**: The browser-to-Cloudflare Worker segment uses HTTPS/WSS, while the Worker-to-target-host segment uses the complete SSH-2.0 protocol. The SSH segment supports Curve25519-SHA256 (preferred) and ECDH-NISTP256 key exchange, AES-256-GCM (preferred) / AES-128-GCM / AES-256-CTR encryption, and HMAC-SHA2-256/512 integrity verification.
-- **Multi-Algorithm Host Key Verification**: Supports Ed25519, ECDSA P-256/P-384/P-521, and RSA signature verification, with SHA-256 fingerprint display on first connection (TOFU mode).
-- **Security Hardening**: Built-in SSRF protection against IPv6 and reserved addresses. `/api/ssh` uses a bounded, per-Worker-isolate in-memory limiter for traffic shedding, while connection authorization remains the responsibility of Turnstile or one-time connection tokens. Saved server credentials are encrypted with AES-256-GCM in per-user Durable Object SQLite storage.
-- **Human Verification**: Supports Cloudflare Turnstile verification to prevent malicious bot abuse.
-- **Isolated Session State**: Each SSH terminal session is managed by an independent Cloudflare Durable Object. Browser WebSockets use the Hibernation API entry pattern, but an active outbound SSH TCP connection keeps the Durable Object awake for the duration of the session.
-- **Internal Flow for Saved Credentials**: When connecting to a saved server, UserDBDO decrypts the credential on the server side and passes it internally to SSHSessionDO through a one-time connection token; the browser never receives the plaintext credential. Anonymous connections and the initial save still send user input to the Worker over HTTPS/WSS.
+- **Two-Segment Encryption**: HTTPS/WSS between browser and Worker; the Worker-to-server segment uses the full SSH-2.0 protocol (Curve25519-SHA256/ECDH-NISTP256 key exchange, AES-256-GCM/CTR encryption, HMAC-SHA2 integrity).
+- **Host-Key Verification**: Ed25519/ECDSA P-256/P-384/P-521/RSA signature checks with a SHA-256 fingerprint on first connection (TOFU).
+- **Defense in Depth**: IPv6/reserved-address SSRF blocking plus DNS-rebinding protection, bounded in-memory rate limiting, Turnstile verification, and AES-256-GCM encryption for saved credentials in per-user SQLite storage.
+- **Session Isolation**: Each terminal session runs in an independent Durable Object; an active outbound SSH TCP connection keeps it awake.
+- **Internal Credential Flow**: On one-click connect, the server decrypts credentials and hands them to the session via a one-time token; the browser never sees the plaintext.
 
 <a id="features"></a>
+
 ## Features
 
 - **Pure TypeScript SSH-2.0 Implementation**: Fully self-developed SSH protocol stack, with no dependency on any third-party SSH libraries, implementing all cryptographic operations based on Web Crypto API.
@@ -96,10 +97,12 @@
 - **Customizable UI**: Theme V2 includes Standard Dark, Standard Light, Cyberpunk, Glacier, and Gruvbox. The companion [GitHub Pages theme editor](https://newbietan.github.io/CloudSSH/) provides live controls for colors, shape, density, font, shadows, motion, and button/input/card/tab styles, with previews for login, server list, terminal + SFTP, and the AI Agent panel. Themes are imported, exported, backed up, and shared as JSON files. Signed-in users sync imported themes to their account for cross-browser restoration, while anonymous users keep them in the current browser only.
 - **SFTP Graphical File Manager**: Integrated with a complete SFTP v3 file transfer protocol, providing a graphical file browser interface. Supports directory browsing, file upload/download, creating new folders, file renaming, and deletion, plus plain selection, `Cmd/Ctrl` toggle selection, `Shift` range selection, select all, batch file downloads, and batch deletion. Built on the SSH subsystem, it runs alongside terminal sessions without interference and supports download queues and upload cancellation.
 - **Native File Transfer**: Integrated with [trzsz.js](https://github.com/trzsz/trzsz.js), supporting `trz` (upload) / `tsz` (download) commands for file transfer, fully compatible with tmux sessions. Also supports drag-and-drop file upload to the terminal, directory transfer, and resumable transfers. (Requires [trzsz](https://trzsz.github.io/) installed on the remote server)
-- **GitHub OAuth Integration**: Supports GitHub login, allowing users to save and manage frequently used SSH servers for one-click connections. Each server can have up to 10 normalized tags; the list supports instant search by name, host, or username, tag filtering, and pagination with 9 server cards per page.
+- **Bilingual UI**: Ships built-in Simplified Chinese and English translations, automatically following the browser language with a manual override; the choice is persisted via a URL parameter or local storage (`cloudssh_locale`).
+- **GitHub OAuth Integration**: Supports GitHub login, allowing users to save and manage frequently used SSH servers for one-click connections. Each server can have up to 10 normalized tags; the list supports instant search by name, host, or username, tag filtering, and responsive pagination (9 cards per page on desktop, 6 on tablets, 3 on mobile).
+- **Custom Command Snippets**: Signed-in users can save frequently used commands under a name and reuse them via server-side search. Snippets are stored in `UserDBDO` with per-`user_id` row-level isolation (name ≤50, command ≤2000, ≤100 per user); anonymous users fall back to local `localStorage`. Supports fill-in, fill-and-run, edit, and delete, reachable from the toolbar on desktop and mobile, and hidden inside one-time share sessions.
 - **Automatic Server OS Detection**: When a signed-in user first connects to a saved server without an OS record, CloudSSH uses a separate SSH exec channel after the terminal is ready to read `/etc/os-release` or `uname`, then shows the corresponding system icon on the server card. Detection runs in the background without blocking the terminal. Only recognized results are saved; unknown results are retried naturally on the next connection, and changing the host or port clears stale results. Anonymous connections do not run this check. The read-only command may appear in the target server's SSH audit logs.
 - **Private IP Display and Quick Copy**: Valid IPv4 and IPv6 addresses are visually masked in the saved-server list and connection status bar to reduce accidental disclosure in demos or screenshots. The complete connection address remains available through mouse or keyboard copy. Hostnames remain unchanged; visual masking is not encryption or access control.
-- **Single-Page Multi-Tab Session**: Switch between multiple independent SSH terminal and SFTP instances within a single browser tab, with isolated sandbox environments.
+- **Single-Page Multi-Tab Session**: Switch between multiple independent SSH terminal and SFTP instances within a single browser tab, with isolated sandbox environments. While on the server list or anonymous connection page, a toolbar/form button returns you to an established SSH session in one click, and pressing `Esc` does the same when the terminal is hidden; the button appears and hides along with the tab count.
 - **Secure Connection History**: Saves last 5 connection records locally. Credentials (passwords/private keys) can be client-side encrypted using locally derived AES-256-GCM keys.
 - **Dual-Segment Latency & Colo Display**: Instantly and periodically monitor WebSocket RTT (client to CF), physical latency (CF to SSH host), and the current Cloudflare datacenter code (e.g. `CF-LAX`) on the status bar, with green, yellow, and red indicators for network quality.
 - **Smart Region Scheduling (locationHint)**: Queries IPinfo when a direct server is saved, persists the inferred Durable Object region, and reuses it on connection without another runtime geo lookup. With SSH jumps, only the outermost entry reached directly by Cloudflare is inferred; downstream private servers do not trigger a lookup and inherit placement from that entry. Failures fall back to Cloudflare's default placement, and users may manually override direct-entry regions. _Note: automatic inference sends the direct entry's host information to the third-party IPinfo service. locationHint is a Cloudflare best-effort feature and may fall back to a nearby region when capacity is unavailable._
@@ -109,6 +112,7 @@
 - **Quality Gates**: Before deploying either `test` or `main`, GitHub Actions performs frozen-lockfile installation, Worker/frontend type checking, unit and integration tests, reproducible frontend builds, Playwright browser E2E, and axe accessibility regression. Any failure blocks deployment.
 
 <a id="architecture"></a>
+
 ## Architecture
 
 ### System Architecture
@@ -147,63 +151,8 @@ flowchart TB
     AgentCore <-->|"LLM API"| External["External LLM Service"]
 ```
 
-### Core Components
-
-| Component | File | Responsibility |
-|-----------|------|----------------|
-| **Worker Entry** | `src/worker/index.ts` | HTTP routing, API handling, WebSocket upgrade |
-| **SSHSessionDO** | `src/worker/durable-object.ts` | SSH session lifecycle management, SSRF protection |
-| **UserDBDO** | `src/worker/user-db.ts` | Per-GitHub-user data, sessions, server configs, normalized tags, and encrypted credentials (SQLite) |
-| **SSHShareDO** | `src/worker/share-do.ts` | One-time capability, short-lived connection ticket, expiry/revocation state, and the share-session-only audit log |
-| **IP Geo Inference** | `src/worker/ip-geo.ts` | Infers the Cloudflare-direct entry IP at save time and maps it to a DO locationHint; downstream jump nodes are not queried |
-| **OS Detection** | `src/worker/os-detect.ts` | Parses remote system identity and normalizes persistable OS keys |
-| **SSHSession** | `src/worker/ssh-session.ts` | SSH protocol state machine (connect→version→kex→auth→interactive) |
-| **SSH Jump Stream** | `src/worker/direct-tcpip-stream.ts` | Backpressured duplex byte stream that runs nested SSH over an RFC 4254 `direct-tcpip` channel |
-| **SSH Protocol Stack** | `src/ssh/*.ts` | Pure TypeScript SSH-2.0 implementation (transport, crypto, auth, channels) |
-| **SFTP Handler** | `src/worker/sftp-handler.ts` | SFTP protocol operations, task queue, concurrent downloads, upload tracking and cancellation |
-| **SFTP Protocol** | `src/ssh/sftp.ts` / `sftp-types.ts` | SFTP v3 protocol client, packet parsing and type definitions |
-| **Frontend Terminal** | `frontend/src/terminal.ts` | xterm.js wrapper, native right-click paste, dynamic RTT heartbeats, three-color network quality indicators, terminal search, selection-to-Agent actions, and WebSocket management |
-| **Mobile Controller** | `frontend/src/mobile-terminal.ts` / `mobile-input.ts` | Dynamic viewport sizing, iOS IME fallback, touch shortcuts, clipboard actions, and optional fullscreen landscape |
-| **Tab Manager** | `frontend/src/tab-manager.ts` | Single-page coordinator for isolated terminal, SFTP, Agent, and pending-context state in each session tab, including copyable masked-IP display |
-| **Server List** | `frontend/src/server-list.ts` | Server-card management, search, tag filtering, private IP display, and pagination with 9 items per page |
-| **SSH Share UI** | `frontend/src/share-manager.ts` / `share-session.ts` | Owner-side creation, revocation, and audit viewing plus explicit recipient consent and one-time claim |
-| **Host Display** | `frontend/src/host-display.ts` | Validates IPv4/IPv6 literals and produces consistent privacy-masked display text |
-| **SFTP Panel** | `frontend/src/sftp-panel.ts` | Graphical file manager UI with multi-selection, batch download/delete, transfer queues, and cancellation |
-| **AI Agent** | `src/worker/agent/core.ts` | AI control loop: LLM streaming calls, tool execution, environment detection, terminal context reading |
-| **Agent Tools** | `src/worker/agent/tools.ts` | 8 operations tools (execute command, terminal context, environment detection, process list, service management, Docker management, user confirmation, report output) |
-| **Agent Safety** | `src/worker/agent/safety.ts` | Two-layer security: direct blocking (rm -rf /, fork bomb, etc.) + confirmation prompts (rm, shutdown, iptables, etc.) |
-| **Agent Panel** | `frontend/src/agent/agent-panel.ts` | AI assistant sidebar UI with terminal-selection attachments, streaming output, Markdown rendering, code-block copy and safe terminal fill, collapsible thinking process, and safe confirmation dialogs |
-| **Agent Selection Context** | `frontend/src/agent/terminal-selection-context.ts` | Preserves terminal-selection snapshots and composes user questions with an explicit untrusted-data boundary |
-| **AI Config** | `frontend/src/ai-config.ts` | AI model configuration modal for Base URL / API Key / model selection |
-| **Region Options** | `frontend/src/regions.ts` | Shared DO locationHint region options component for server management and anonymous connection forms |
-
-### SSH Protocol Implementation
-
-This project implements a complete SSH-2.0 protocol stack:
-
-| Layer | Implementation | Supported Algorithms |
-|-------|----------------|---------------------|
-| **Key Exchange** | `kex-curve25519.ts` / `kex-ecdh.ts` | curve25519-sha256, ecdh-sha2-nistp256 |
-| **Data Encryption** | `crypto.ts` | aes256-gcm, aes128-gcm, aes256-ctr, aes192-ctr, aes128-ctr |
-| **Integrity** | `crypto.ts` | hmac-sha2-256, hmac-sha2-512, hmac-sha1 |
-| **Host Keys** | `ssh-session.ts` | Ed25519, ECDSA P-256/P-384/P-521, RSA |
-| **User Auth** | `auth.ts` | Password and RFC 4256 keyboard-interactive; Ed25519, ECDSA P-256/P-384/P-521, and RSA-SHA2 private-key authentication |
-| **Channel Management** | `channel.ts` | Session, `direct-tcpip`, SFTP subsystem, PTY, shell, and window-change channels |
-| **SFTP Protocol** | `sftp.ts` / `sftp-types.ts` | SFTP v3 file transfer protocol (directory browsing, upload, download, delete, rename) |
-
-### Data Flow
-
-1. The user enters the host IP, username, and password on the frontend (or selects a saved server via GitHub OAuth).
-2. The frontend establishes a WebSocket connection with the backend Durable Object.
-3. SSHSessionDO receives the credentials and uses `@cloudflare/sockets` to connect to the direct target or outermost jump host.
-4. When a jump path exists, SSHSession authenticates each hop and carries the next SSH session over RFC 4254 `direct-tcpip`; only the final target opens PTY, Shell, SFTP, and Agent exec channels.
-5. Terminal data travels over WSS between the browser and Worker, and over SSH between the Worker and target server; the Worker bridges the two protocol segments and processes SSH.
-6. SFTP file management runs on a separate SSH subsystem channel, supporting directory browsing, file upload/download, and other operations.
-7. For a saved server without an OS record, SSHSession performs one read-only system check through a separate exec channel after the Shell is ready. Recognized results are stored in UserDBDO and sent to the frontend; unknown results are not stored.
-8. The AI Agent receives the user question and optional terminal-selection context via WebSocket. The selection is marked as untrusted analysis data before AgentCore calls the external LLM API, executes approved commands through SSH exec channels, and streams results back to the frontend.
-9. A one-time share is atomically claimed by SSHShareDO and exchanged for a short-lived connection ticket. The share session writes lifecycle, SFTP, and terminal-output events to its isolated audit store, and closes on expiry, revocation, or audit failure.
-
 <a id="quick-start"></a>
+
 ## Quick Deployment
 
 ### Prerequisites
@@ -243,37 +192,22 @@ A fork can use the built-in `Sync upstream` GitHub Actions workflow to periodica
 
 > **Sync behavior**: The workflow uses GitHub's fork synchronization API, requires no PAT, and never force-overwrites the branch. If your `main` branch cannot be merged with upstream automatically, the job fails while preserving the existing code and the conflict must be resolved manually. Avoid editing the deployment `main` branch directly, and keep domains, secrets, and environment variables in the Cloudflare Dashboard.
 
-#### Method 2: Local CLI Deployment
+#### Configurable Environment Variables
 
-1. **Clone the Repository**
-   ```bash
-   git clone https://github.com/newbietan/CloudSSH.git
-   cd CloudSSH
-   ```
+All optional features are controlled by Worker environment variables set in the Cloudflare Dashboard under Settings → Variables and Secrets (sensitive ones should use the **Secret** type) and applied on the next redeploy:
 
-2. **Install Dependencies**
-   ```bash
-   npm install -g pnpm
-   pnpm install
-   cd frontend && pnpm install
-   ```
+| Environment Variable | Required | Description |
+| --- | --- | --- |
+| `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET` | Required for GitHub login | GitHub OAuth application credentials |
+| `BASE_URL` | Required for GitHub login | OAuth callback URL; must match your deployed domain |
+| `GITHUB_ALLOWED_USER_IDS` | Optional | Comma-separated GitHub **numeric user IDs** allowed to sign in; omitted = unrestricted, an empty or malformed value fails closed |
+| `REQUIRE_GITHUB_AUTH` | Optional | Set to `true` to disable anonymous SSH and require a valid GitHub session for every connection |
+| `ENABLE_SSH_SHARING` | Optional | Set to `true` to enable one-time SSH sharing (disabled by default) |
+| `TURNSTILE_SECRET` / `TURNSTILE_SITEKEY` | Optional | Cloudflare Turnstile human-verification keys |
+| `STRICT_HOST_KEY_VERIFY` | Optional | Host-key signature verification: set to `false` to skip verification failures (default `true`, fails closed) |
+| `DEBUG_MODE` | Optional | Set to `true` to output debug information (`wrangler.toml` defaults to `false`) |
 
-3. **Login to Cloudflare**
-   ```bash
-   npx wrangler login
-   ```
-
-4. **Deploy Production**
-   ```bash
-   pnpm run deploy
-   ```
-
-5. **Deploy Test Environment** (Optional)
-   ```bash
-   pnpm run deploy:test
-   ```
-
-> **Note**: Both environments bind to Durable Objects with the same `class_name`, but data is completely isolated due to different Worker names. After deployment, you can bind different custom domains for each environment in the Cloudflare Dashboard (Settings → Domains & Routes).
+> **Note**: For local CLI deployment or debugging the Worker, see the Local Development section under Development below.
 
 #### Optional: Configure Turnstile Human Verification
 
@@ -323,14 +257,14 @@ With GitHub OAuth enabled, users can log in with their GitHub account and save/m
 
    Use `id`, not the username or `node_id`. The numeric ID does not change when the username changes; separate multiple IDs with commas.
 
-   | Configuration | GitHub sign-in | Anonymous SSH |
-   |---------------|----------------|---------------|
-   | Neither setting | All GitHub users | Allowed |
-   | `GITHUB_ALLOWED_USER_IDS` only | Allowlisted users only | Allowed |
-   | `REQUIRE_GITHUB_AUTH=true` only | All GitHub users | Disabled |
-   | Both settings | Allowlisted users only | Disabled (private-instance mode) |
+| Configuration                   | GitHub sign-in         | Anonymous SSH                    |
+| ---------------                 | ----------------       | ---------------                  |
+| Neither setting                 | All GitHub users       | Allowed                          |
+| `GITHUB_ALLOWED_USER_IDS` only  | Allowlisted users only | Allowed                          |
+| `REQUIRE_GITHUB_AUTH=true` only | All GitHub users       | Disabled                         |
+| Both settings                   | Allowlisted users only | Disabled (private-instance mode) |
 
-3. **Redeploy**: Save the variables and redeploy the existing Worker. The Durable Object migration in the repository initializes the required classes and database; deleting the existing Worker is not required.
+1. **Redeploy**: Save the variables and redeploy the existing Worker. The Durable Object migration in the repository initializes the required classes and database; deleting the existing Worker is not required.
 
 > **Environment Variable Type Recommendation**: `GITHUB_CLIENT_SECRET` must use the **Secret** type. `GITHUB_ALLOWED_USER_IDS` and `REQUIRE_GITHUB_AUTH` contain no credentials and may use plain-text variables. Secrets are stored in Cloudflare's encrypted storage, separate from code deployments, and will not be overwritten or lost during redeployments.
 
@@ -362,6 +296,7 @@ Jump hosts require no additional environment variables, but GitHub OAuth and sav
 Every server in a jump relation must belong to the same GitHub user. Self-references and cycles are rejected, and a jump host cannot be deleted while another server references it. Public-address SSRF checks and Durable Object region placement use the outermost address reached directly by Cloudflare. Only that entry runs automatic region inference; selecting a jump host disables the downstream server's region option and does not send its private host information to IPinfo. Private targets are accepted only inside a server-resolved saved chain, and anonymous clients cannot submit jump configuration. TOFU host-key verification runs at every hop, with private target records scoped by the complete jump path.
 
 <a id="development"></a>
+
 ## Development
 
 ### Project Structure
@@ -373,13 +308,20 @@ CloudSSH/
 ├── src/                    # Backend source (Cloudflare Worker)
 │   ├── ssh/                # SSH protocol pure implementation layer
 │   └── worker/             # Worker entry and Durable Objects
+│       ├── agent/          # AI Agent control loop, tools, safety
+│       ├── dns-check.ts    # DNS-rebinding SSRF defense
+│       └── ip-geo.ts       # IPinfo region inference → locationHint
 ├── frontend/               # Frontend source (independent workspace)
 │   └── src/                # TypeScript + xterm.js + trzsz
+│       ├── agent/          # AI assistant sidebar UI
+│       └── i18n/           # Chinese/English strings and locale resolution
 ├── docs/                   # GitHub Pages static assets
 │   └── theme-editor/       # Visual theme editor
 ├── scripts/                # Build scripts
-├── tests/                  # Vitest, Playwright, and axe regression tests
-├── .github/workflows/      # CI quality gates and deployment workflows
+├── tests/                  # Vitest unit/integration + Playwright E2E and axe regression (build/ e2e/ ssh/ worker/)
+├── .github/workflows/      # CI/CD workflows (deploy / github-pages / sync-upstream)
+├── biome.json              # Code formatting and lint conventions
+├── playwright.config.ts    # Browser E2E test configuration
 ├── pnpm-workspace.yaml     # pnpm workspace configuration
 └── wrangler.toml           # Cloudflare deployment configuration
 ```
@@ -389,29 +331,35 @@ CloudSSH/
 #### Environment Setup
 
 1. **Fork and Clone the Repository**
+
    ```bash
    git clone https://github.com/<your-username>/CloudSSH.git
    cd CloudSSH
    ```
 
 2. **Install Dependencies** (root and frontend separately)
+
    ```bash
    pnpm install
    cd frontend && pnpm install
    ```
 
 3. **Login to Cloudflare** (required on first run, credentials are cached afterward)
+
    ```bash
    npx wrangler login
    ```
+
    > **Note**: When using Wrangler Dev for local development, it connects to your Cloudflare account to access Durable Objects and TCP Sockets. Real SSH TCP traffic is forwarded through Cloudflare's infrastructure.
 
 4. **Configure GitHub Actions** (Optional, for automatic deployment)
-   
+
    If you want to deploy to your own Cloudflare account via GitHub Actions, modify the repository owner in `.github/workflows/deploy.yml`:
+
    ```yaml
    if: github.repository_owner == 'your-github-username'
    ```
+
    Also configure the following Secrets in your repository Settings → Secrets and variables → Actions:
    - `CLOUDFLARE_API_TOKEN`: Your Cloudflare API Token
    - `CLOUDFLARE_ACCOUNT_ID`: Your Cloudflare Account ID
@@ -423,6 +371,7 @@ pnpm run dev
 ```
 
 This command builds the frontend and starts the Wrangler local development environment, supporting:
+
 - Automatic rebuild on frontend code changes
 - Automatic reload on Worker code changes
 - Full Durable Objects and TCP Sockets functionality
@@ -431,15 +380,15 @@ After the dev server starts, visit the local address shown in the terminal (usua
 
 #### Common Development Commands
 
-| Command | Description |
-|---------|-------------|
-| `pnpm run dev` | Build frontend + start Wrangler dev server |
-| `pnpm run build:frontend` | Build frontend only (output to `frontend/dist/`) |
-| `pnpm run typecheck` | Type-check Worker and frontend TypeScript |
-| `pnpm test` | Run Vitest unit and integration tests |
-| `pnpm run test:e2e` | Run Playwright browser E2E and axe accessibility tests |
-| `pnpm run verify` | Run type checks, tests, production build, and browser E2E |
-| `pnpm run deploy:test` | Build and deploy the isolated test environment |
+| Command                   | Description                                               |
+| ---------                 | -------------                                             |
+| `pnpm run dev`            | Build frontend + start Wrangler dev server                |
+| `pnpm run build:frontend` | Build frontend only (output to `frontend/dist/`)          |
+| `pnpm run typecheck`      | Type-check Worker and frontend TypeScript                 |
+| `pnpm test`               | Run Vitest unit and integration tests                     |
+| `pnpm run test:e2e`       | Run Playwright browser E2E and axe accessibility tests    |
+| `pnpm run verify`         | Run type checks, tests, production build, and browser E2E |
+| `pnpm run deploy:test`    | Build and deploy the isolated test environment            |
 
 #### Submitting Changes
 
@@ -459,35 +408,38 @@ test branch (dev/test)  ──merge──>  main branch (production)
 
 ### Tech Stack
 
-| Layer | Technology | Description |
-|-------|------------|-------------|
-| **Frontend** | TypeScript + Vite + xterm.js | Web terminal emulator, WebGL hardware acceleration |
-| **UI Framework** | Tailwind CSS (local Vite/PostCSS build) + Theme V2 | The app supports built-in theme switching, custom JSON import, and signed-in account sync; editing and export live on GitHub Pages |
-| **File Transfer** | trzsz.js | Supports trz/tsz commands, drag-and-drop upload, resumable transfers |
-| **AI Assistant** | BYOK + OpenAI-compatible API | Bring your own API key, supports DeepSeek and other compatible models |
-| **Backend** | Cloudflare Workers | Serverless edge computing |
-| **Session Management** | Durable Objects | SSH session isolation; browser WebSockets use the Hibernation API entry pattern, while active outbound TCP prevents hibernation |
-| **Data Storage** | Durable Objects SQLite | User data, server configurations |
-| **Package Manager** | pnpm (workspace) | Monorepo dependency management |
+| Layer                  | Technology                                         | Description                                                                                                                        |
+| -------                | ------------                                       | -------------                                                                                                                      |
+| **Frontend**           | TypeScript + Vite + xterm.js                       | Web terminal emulator, WebGL hardware acceleration                                                                                 |
+| **i18n**               | Lightweight custom i18n (`frontend/src/i18n`)      | Simplified Chinese / English dual-language UI with automatic browser detection and manual switching                                |
+| **UI Framework**       | Tailwind CSS (local Vite/PostCSS build) + Theme V2 | The app supports built-in theme switching, custom JSON import, and signed-in account sync; editing and export live on GitHub Pages |
+| **File Transfer**      | trzsz.js                                           | Supports trz/tsz commands, drag-and-drop upload, resumable transfers                                                               |
+| **AI Assistant**       | BYOK + OpenAI-compatible API                       | Bring your own API key, supports DeepSeek and other compatible models                                                              |
+| **Backend**            | Cloudflare Workers                                 | Serverless edge computing                                                                                                          |
+| **Session Management** | Durable Objects                                    | SSH session isolation; browser WebSockets use the Hibernation API entry pattern, while active outbound TCP prevents hibernation    |
+| **Data Storage**       | Durable Objects SQLite                             | User data, server configurations                                                                                                   |
+| **Package Manager**    | pnpm (workspace)                                   | Monorepo dependency management                                                                                                     |
 
 <a id="contributors"></a>
+
 ## Contributors
 
 Thank you to the following contributors for improving CloudSSH's code, compatibility, and user experience:
 
-| Contributor | Key Contributions |
-|-------------|-------------------|
-| [TanXin (@newbietan)](https://github.com/newbietan) | Project creator and maintainer; Cloudflare Serverless architecture, SSH/SFTP, AI Agent, security, theming, and engineering infrastructure |
-| [David xu (@xqdoo00o)](https://github.com/xqdoo00o) | Dropbear compatibility, migration to trzsz file transfer, PTY sizing, and session exit/reconnection improvements |
-| [vonl1 (@vonl1)](https://github.com/vonl1) | Terminal selection auto-copy, Vim-compatible right-click paste, masked IPv4/IPv6 display with quick full-address copy, and automatic server OS detection with branded icons |
-| [Leon Xu (@xuthuslei)](https://github.com/xuthuslei) | Fixed encryption-state transitions and packet parsing when `SSH_MSG_NEWKEYS` and the first encrypted packet arrive in the same TCP chunk |
+| Contributor                                          | Key Contributions                                                                                                                                                           |
+| -------------                                        | -------------------                                                                                                                                                         |
+| [TanXin (@newbietan)](https://github.com/newbietan)  | Project creator and maintainer; Cloudflare Serverless architecture, SSH/SFTP, AI Agent, security, theming, and engineering infrastructure                                   |
+| [David xu (@xqdoo00o)](https://github.com/xqdoo00o)  | Dropbear compatibility, migration to trzsz file transfer, PTY sizing, and session exit/reconnection improvements                                                            |
+| [vonl1 (@vonl1)](https://github.com/vonl1)           | Terminal selection auto-copy, Vim-compatible right-click paste, masked IPv4/IPv6 display with quick full-address copy, and automatic server OS detection with branded icons |
+| [Leon Xu (@xuthuslei)](https://github.com/xuthuslei) | Fixed encryption-state transitions and packet parsing when `SSH_MSG_NEWKEYS` and the first encrypted packet arrive in the same TCP chunk                                    |
 
 The list and contribution summaries are based on Git history and accepted Pull Requests; one contributor may appear under multiple historical Git author names or email addresses. See [GitHub Contributors](https://github.com/newbietan/CloudSSH/graphs/contributors) for the complete record. Issues and Pull Requests are welcome.
 
 <a id="license"></a>
+
 ## License
 
-This project is open-sourced under the [Apache License 2.0](LICENSE). 
+This project is open-sourced under the [Apache License 2.0](LICENSE).
 
 **Original Author and Attribution Requirement**: CloudSSH was initiated and architected by [TanXin (@newbietan)](https://github.com/newbietan), who continues to maintain the project. Any modified, derivative, or redistributed version based on this project must retain the license, copyright, and attribution notices in [LICENSE](LICENSE) and [NOTICE](NOTICE), and clearly state in its documentation or other accompanying notices: “This project is based on CloudSSH, originally created by TanXin (@newbietan),” together with a link to the original project.
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudssh-frontend",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudssh",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "packageManager": "pnpm@11.8.0",
   "description": "纯 Cloudflare 架构 Web SSH 工具",
   "main": "src/worker/index.ts",

--- a/tests/README.md
+++ b/tests/README.md
@@ -10,12 +10,19 @@ tests/
 ├── e2e/                           # Chromium 浏览器交互与 axe 无障碍检查
 ├── ssh/                           # SSH 算法、认证、加密、KEX、Packet 与测试密钥夹具
 ├── worker/                        # Worker 路由、安全、DNS、UserDB 与标签测试
-├── agent-code-actions.test.ts     # Agent 代码块复制/填入规则
+├── agent-code-actions.test.ts # Agent 代码块复制/填入规则
 ├── agent-terminal-selection.test.ts # 终端选区附件和非授权安全边界
+├── auth-challenge-dialog.test.ts # RFC 4256 认证挑战对话框交互
 ├── clipboard.test.ts              # Clipboard API 与旧版复制回退
-├── frontend-ux.test.ts            # 前端关键交互源码回归
+├── frontend-ux.test.ts            # 前端关键交互源码回归（标签栏/状态栏渲染等）
+├── host-display.test.ts           # IPv4/IPv6 掩码与完整地址复制
 ├── i18n.test.ts                   # 中英文词条和语言解析
+├── known-hosts.test.ts            # 已知主机指纹 TOFU 信任与变更流程
+├── mobile-input.test.ts           # iOS IME diff 与一次性修饰键帮助函数
+├── share-session.test.ts          # 分享会话确认/领取幂等与页面状态
 ├── sftp-selection.test.ts         # SFTP 单选、多选、连选和全选模型
+├── snippet-local-store.test.ts    # 匿名命令片段 localStorage 存储与限额
+├── snippet-schema.test.ts         # 片段名称/命令/数量校验与规范化
 ├── terminal-status.test.ts        # SSH 状态事件翻译
 ├── terminal-text.test.ts          # 终端文本处理
 ├── theme.test.ts                  # 内置/自定义主题
@@ -64,15 +71,17 @@ pnpm run verify
 - Origin 检查、端口范围、连接令牌和错误信息边界
 - IPv4/IPv6 保留地址、DoH 解析与 DNS rebinding 防护
 - Agent 危险命令拦截、确认规则和 SSRF URL 校验
-- UserDB 服务器标签迁移、规范化、序列化和更新
+- 主机密钥信任：首见指纹确认、更换指纹阻断与路由作用域隔离
+- 键盘交互认证、OS 检测、跳板链、SFTP 上传冲突、分享会话策略
+- UserDB 服务器标签/片段迁移、规范化、序列化、更新与隔离
 
 ### 前端与构建
 
-- 服务器搜索、标签筛选和每页 9 项分页
+- 服务器搜索、标签筛选和响应式分页（桌面 9 / 平板 6 / 移动 3）
 - SFTP 单选、Cmd/Ctrl 多选、Shift 连选和全选
 - Agent 终端选区附件、问题组合和非授权安全边界
 - 终端选区自动复制、指针取消和旧版复制回退
-- i18n、主题、终端状态和文本处理
+- i18n、主题、终端状态/文本、已知主机与片段本地存储
 - 构建可复现性、xterm 生产构建兼容和原生弹窗禁用
 
 ### 浏览器 E2E
@@ -82,6 +91,8 @@ pnpm run verify
 - 服务器标签筛选与分页
 - Agent 终端选区附件
 - 终端选区复制与焦点恢复
+- 认证挑战对话框、iOS 输入法、移动端后台连接恢复与分享会话领取
+- SFTP 覆盖确认、主题样式与 UI 回归
 
 ## 当前限制
 


### PR DESCRIPTION
## 版本内容

v1.10.2 为文档与 CI 工作流更新版本（无代码变更），包含以下提交：

| 提交 | 说明 |
| --- | --- |
| `11149d7` | docs: 全面更新项目文档并精简 README 结构 |
| `2b36ff4` | ci: 修复文档变更误触发部署的 paths-ignore 作用域 |
| `71ea521` | release: 发布 v1.10.2 版本（版本号 + CHANGELOG） |

## 更新要点

**文档（README 中英双语）**
- 核心优势要点化：重点、全面、不啰嗦
- 架构说明仅保留系统架构图，移除核心组件 / SSH 协议实现 / 数据流三个小节
- 快速部署移除本地命令行部署方式，新增「可配置环境变量」汇总表
- 更新演示视频时长 8:27 → 19:48

**维护文档**
- AGENTS.md：补齐目录树（前端工具模块、dns-check/ip-geo 等）、环境变量、tests/ 结构与 5 条新坑位
- tests/README.md：补充 7 个新测试文件与覆盖范围

**CI 修复**
- `paths-ignore` 作用域：`*` 不匹配 `/`，原 `*.md` 仅忽略根目录文档，导致 `tests/README.md` 等子目录文档变更误触发完整部署；改为 `**/*.md` 等跨目录模式

## 验证结果

- `pnpm run typecheck` 通过
- `pnpm test` 通过（47 个测试文件 / 603 个用例）
- `pnpm run build:frontend` 构建成功
- CI 完整门禁（typecheck + test + 可复现构建 + Playwright E2E + axe）在 `2b36ff4` 已绿色通过

> ⚠️ 已知后续事项（不在本版本范围）：zizmor 建议将 `.github/workflows` 中的 action 引用按 SHA 锁定（当前为 tag 引用），可作后续安全加固跟进。