### PR TITLE
release: 发布 v1.12.1 审计清理记录时间展示完善版本

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.12.1] - 2026-08-26
+
+### Added
+
+- 新增 `share.auditCleanupStatus` 中英词条（`{status}（审计 {time}）` / `{status} (audit {time})`）。
+
+### Changed
+
+- 审计清理记录折叠区每行扩展展示审计生成时间：「清理时间 + 状态（审计时间）· 方式」；审计时间取首次审计事件时间（`claimed_at`，认领时写入 `share.claimed`），`created_at` 兜底。
+
 ## [1.12.0] - 2026-08-26
 
 ### Added

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudssh-frontend",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -254,6 +254,7 @@ export const enUS: Record<keyof typeof zhCN, string> = {
     'This permanently deletes all audit details (including terminal output and operations), keeping only a single tombstone marker. This cannot be undone.',
   'share.auditPurged': 'Audit log purged',
   'share.auditCleanupLog': 'Audit purge log',
+  'share.auditCleanupStatus': '{status} (audit {time})',
   'share.auditPurgeManual': 'Manually purged',
   'share.auditPurgeAuto': 'Auto-purged after retention',
   'share.auditRemovalHint':

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -209,6 +209,7 @@ export const zhCN = {
     '将永久删除全部审计明细（含终端输出与操作记录），仅保留一条清除标记。此操作不可恢复。',
   'share.auditPurged': '审计记录已清空',
   'share.auditCleanupLog': '审计清理记录',
+  'share.auditCleanupStatus': '{status}（审计 {time}）',
   'share.auditPurgeManual': '手动清空',
   'share.auditPurgeAuto': '到期自动清理',
   'share.auditRemovalHint': '已清除的明细不可恢复，此处仅保留清理操作的记录。',

--- a/frontend/src/share-manager.ts
+++ b/frontend/src/share-manager.ts
@@ -226,7 +226,7 @@ export class ShareManager {
                 ${t('share.auditCleanupLog')}（${purged.length}）
               </summary>
               <div class="space-y-1 mt-2">
-                ${purged.map((share) => `<div class="text-[10px] text-muted"><span class="text-dim">${escapeHtml(formatTime(share.auditPurgedAt ?? null))}</span> ${escapeHtml(t(`share.status.${share.status}` as never))} · ${share.auditPurgeType === 'auto' ? t('share.auditPurgeAuto') : t('share.auditPurgeManual')}</div>`).join('')}
+                ${purged.map((share) => `<div class="text-[10px] text-muted"><span class="text-dim">${escapeHtml(formatTime(share.auditPurgedAt ?? null))}</span> ${escapeHtml(t('share.auditCleanupStatus', { status: t(`share.status.${share.status}` as never), time: formatTime(share.claimedAt ?? share.createdAt ?? null) }))} · ${share.auditPurgeType === 'auto' ? t('share.auditPurgeAuto') : t('share.auditPurgeManual')}</div>`).join('')}
               </div>
               <p class="text-[10px] text-dim mt-1">${t('share.auditRemovalHint')}</p>
             </details>`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudssh",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "packageManager": "pnpm@11.8.0",
   "description": "纯 Cloudflare 架构 Web SSH 工具",
   "main": "src/worker/index.ts",


### PR DESCRIPTION
## 版本内容

- 审计清理记录折叠区每行扩展展示审计生成时间：「清理时间 + 状态（审计时间）· 方式」
- 审计时间取首次审计事件时间（`claimed_at`，认领时写入 `share.claimed`），`created_at` 兜底
- 新增 `share.auditCleanupStatus` 中英词条（`{status}（审计 {time}）` / `{status} (audit {time})`）
- 纯前端展示层改动，零后端/API 变更

## 提交列表

- 3cae999 `release: 发布 v1.12.1 审计清理记录时间展示完善版本`
- acde66c `feat: 审计清理记录行展示审计生成时间`

## 验证结果

- typecheck:frontend 通过
- i18n 对齐测试 16/16
- build:frontend 构建成功并内联
- 关联 Issue/PR：无（基于 v1.12.0 #103）