### PR TITLE
fix(ssh): restore waitUntilAuthenticated() before opening direct-tcpip on jump hosts

### DIFF
--- a/src/worker/durable-object.ts
+++ b/src/worker/durable-object.ts
@@ -697,6 +697,11 @@ export class SSHSessionDO {
         chainSessions.push(hopSession);
         this.sessionChains.set(ws, chainSessions);
         await hopSession.startHandshake();
+        // Fix regression (v1.11.0 #102 removed this wait): openDirectTcpip requires
+        // state === 'tunnel-ready', which only becomes true after authentication
+        // completes. Without this await, jump host connections always fail with
+        // "SSH jump host is not ready for TCP forwarding".
+        await hopSession.waitUntilAuthenticated();
 
         const destination = jumpHosts[index + 1] || config;
         transport = await hopSession.openDirectTcpip(destination.host, destination.port);


### PR DESCRIPTION
### 背景
v1.11.0（#102）"会话秒级恢复"重构在 `initSSHSession()` 跳板循环中误删了 `await hopSession.waitUntilAuthenticated();`，导致 `openDirectTcpip()` 在跳板会话尚未完成 SSH 握手/认证（状态仍为 `version`/`kex`/`auth`）时就被调用，**所有跳板机连接必现失败**，报错 `SSH jump host is not ready for TCP forwarding`。直连不受影响。

### 修复
在 `startHandshake()` 后恢复等待认证完成，使跳板会话进入 `'tunnel-ready'` 状态后再开 direct-tcpip 通道：

```diff
 await hopSession.startHandshake();
+await hopSession.waitUntilAuthenticated();

 const destination = jumpHosts[index + 1] || config;
 transport = await hopSession.openDirectTcpip(destination.host, destination.port);
```

### 验证
- 本地 typecheck 通过
- 全量测试 649 个全部通过（54 个文件）
- 已在生产环境（Cloudflare Worker）部署验证：跳板连接恢复正常，直连不受影响
- 说明：现有测试套件未覆盖跳板握手时序（这也是该回归漏过 CI 的原因），建议后续补充相关用例

Fixes #108